### PR TITLE
Add .travis.yml for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: c
+
+compiler:
+  - clang
+  - gcc
+
+os: linux
+dist: trusty
+sudo: false
+
+script:
+  - meson builddir
+  - ninja -C builddir
+  - ninja -C builddir test
+
+install:
+  - export PATH="`pwd`/build:${PATH}"
+  - pyenv global system 3.5
+  - wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip && unzip -q ninja-linux.zip -d build
+  - pip3 install meson
+  


### PR DESCRIPTION
This adds continuous integration through [Travis CI](https://travis-ci.org/)

An example can be found here: https://travis-ci.org/ePirat/libplacebo