### PR TITLE
Specify a category mask for newlocale

### DIFF
--- a/src/osdep/printf_useloc_posix.c
+++ b/src/osdep/printf_useloc_posix.c
@@ -31,7 +31,7 @@ static locale_t cloc;
 
 void printf_c_init()
 {
-    cloc = newlocale(0, "C", (locale_t) 0);
+    cloc = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
     if (!cloc)
         abort();
 }


### PR DESCRIPTION
While on Linux it works fine to not specify one, as Linux will fill all not given ones
from the POSIX locale, on BSD using `xlocale.h` this does not work.

When no base locale is given, BSD uses the current locale and fills not matching
bitmasks with values from that one, not with values from the POSIX locale.