### PR TITLE
Bump vulkan version requirement

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -66,7 +66,7 @@ components = [
     'spirv_shaderc.c',
   ], [
     'vulkan',
-    dependency('vulkan', version: '>=1.0', required: false),
+    dependency('vulkan', version: '>=1.0.50', required: false),
     [ 'vulkan/command.c',
       'vulkan/context.c',
       'vulkan/formats.c',


### PR DESCRIPTION
VK_VALIDATION_CHECK_SHADERS_EXT was introduced in vulkan 1.0.50.