### PR TITLE
Miscellaneous Windows fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build*
 /tags
 /TAGS
+*.exe

--- a/demos/sdl2.c
+++ b/demos/sdl2.c
@@ -239,7 +239,7 @@ static void render_frame(const struct ra_swapchain_frame *frame)
     }
 }
 
-int main(int argc, const char **argv)
+int main(int argc, char **argv)
 {
     if (argc < 2 || argc > 3) {
         fprintf(stderr, "Usage: ./sdl2 <image> [<overlay>]\n");

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -49,5 +49,5 @@ static inline bool feq(float a, float b)
 }
 
 #define REQUIRE(cond) require((cond), #cond)
-#define RANDOM (random() / (float) RAND_MAX)
+#define RANDOM (rand() / (float) RAND_MAX)
 #define SKIP 77

--- a/src/utils/upload.c
+++ b/src/utils/upload.c
@@ -47,7 +47,7 @@ void pl_plane_data_from_mask(struct pl_plane_data *data, uint64_t mask[4])
 
     for (int i = 0; i < PL_ARRAY_SIZE(comps); i++) {
         comps[i].size = __builtin_popcount(mask[i]);
-        comps[i].shift = PL_MAX(0, ffsll(mask[i]) - 1);
+        comps[i].shift = PL_MAX(0, __builtin_ffsll(mask[i]) - 1);
     }
 
     // Sort the components by shift


### PR DESCRIPTION
These are some minor changes to get libplacebo to build on Windows for me. They don't include the fix for bstr_xappend_vasprintf and the non-standard behaviour of _vsnprintf yet.