### PR TITLE
meson: search for MoltenVK on macOS

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -18,6 +18,22 @@ build_opts = [
 ]
 
 cc = meson.get_compiler('c')
+vulkan = dependency('vulkan', version: '>=1.0.42', required: false)
+
+# Global dependencies
+build_deps = [
+  dependency('threads'),
+  cc.find_library('m', required: false),
+]
+
+if build_machine.system() == 'darwin'
+  build_deps += [cc.find_library('stdc++', required: true)]
+
+  if not vulkan.found()
+    vulkan = dependency('appleframeworks', modules : ['MoltenVK','Metal','IOSurface','QuartzCore','IOKit','Foundation'], required : false)
+  endif
+endif
+
 if cc.has_argument('-Wincompatible-pointer-types')
   build_opts += ['-Werror=incompatible-pointer-types']
 endif
@@ -26,14 +42,6 @@ endif
 if cc.get_id() == 'clang'
   build_opts += ['-Wno-missing-braces']
 endif
-
-# Global dependencies
-build_deps = [
-  dependency('threads'),
-  cc.find_library('m', required: false),
-]
-
-vulkan = dependency('vulkan', version: '>=1.0.42', required: false)
 
 # Source files
 sources = [

--- a/src/spirv_shaderc.c
+++ b/src/spirv_shaderc.c
@@ -67,8 +67,10 @@ static bool shaderc_init(struct spirv_compiler *spirv)
     if (!p->opts)
         goto error;
 
+#if !__APPLE__
     shaderc_compile_options_set_optimization_level(p->opts,
                                             shaderc_optimization_level_size);
+#endif
 
     int ver, rev;
     shaderc_get_spv_version(&ver, &rev);


### PR DESCRIPTION
This allows compilation of libplacebo on macOS with Vulkan if you have a `MoltenVK.framework` in `/Library/Frameworks`. It also seems that `shaderc` works out of the box from source. 

Note this only enables compilation, the demo does not run entirely (see log below):
```
Requested swap mode unsupported by this device, falling back to VK_PRESENT_MODE_FIFO_KHR
Failed picking any compatible texture format for a plane!
Failed uploading image plane!
[mvk-debug] Initializing MoltenVK timestamping. Mach time: 507790034016576. Time period: 1 / 1 = 1.000000.
Requesting 2 additional vulkan extensions:
    VK_KHR_surface
    VK_MVK_macos_surface
[mvk-info] MoltenVK version 1.0.0. Vulkan version 1.0.69.
[mvk-info] GPU device Intel HD Graphics 5000 (vendorID: 0x8086, deviceID: 0x0a26, pipelineCacheUUID: 55DB2269-9D57-521B-9CC8-69831DDC1F3D) supports the following Metal Feature Sets:
	OSX GPU Family 1 v3
	OSX GPU Family 1 v2
	OSX GPU Family 1 v1
Probing for vulkan devices:
    GPU 0: Intel HD Graphics 5000 (integrated)
Vulkan device properties:
    Device Name: Intel HD Graphics 5000
    Device ID: 8086:a26
    Driver version: 10000
    API version: 1.0.69
Queue families supported by device:
    QF 0: flags 0x7 num 16
Using graphics queue (QF 0)
Creating vulkan device with extensions:
    VK_KHR_swapchain
[mvk-info] Compile MSL source code into a MTLLibrary performance curr: 0.804 ms, avg: 0.804 ms, min: 0.000 ms, max: 0.804 ms, count: 1
[mvk-info] Created VkDevice to run on GPU Intel HD Graphics 5000
Initializing SPIR-V compiler 'shaderc'
Memory heaps supported by device:
    heap 0: flags 0x1 size 1610612736
Memory types supported by device:
    type 0: flags 0x1 heap 0
    type 1: flags 0xf heap 0
    type 2: flags 0xb heap 0
GPU information:
    GLSL version: 450 (vulkan)
    Capabilities: 0x1
    Limits:
      max_tex_1d_dim:            16384
      max_tex_2d_dim:            16384
      max_tex_3d_dim:            2048
      max_pushc_size:            4096
      max_xfer_size:             18446744073709551615
      max_ubo_size:              1073741824
      max_ssbo_size:             1073741824
      max_buffer_texels:         1073741824
      min_gather_offset:         0
      max_gather_offset:         -1
      max_shmem_size:            32768
      max_group_threads:         1024
      max_group_size[0]:         4294967295
      max_group_size[1]:         4294967295
      max_group_size[2]:         4294967295
      max_dispatch[0]:           4294967295
      max_dispatch[1]:           4294967295
      max_dispatch[2]:           4294967295
      align_tex_xfer_stride:     1
      align_tex_xfer_offset:     256
GPU texture formats:
    NAME       TYPE   CAPS   SIZE COMP DEPTH         BITS          GLSL_TYPE  GLSL_FMT  
    r8         UNORM  0x1fb  1    R    {8  0  0  0 } {8  0  0  0 } float      r8        
    r8i        SINT   0x1fb  1    R    {8  0  0  0 } {8  0  0  0 } int        r8i       
    r8s        SNORM  0x1fb  1    R    {8  0  0  0 } {8  0  0  0 } float      r8_snorm  
    r8u        UINT   0x1fb  1    R    {8  0  0  0 } {8  0  0  0 } uint       r8ui      
    rg8        UNORM  0x1fb  2    RG   {8  8  0  0 } {8  8  0  0 } vec2       rg8       
    rg8i       SINT   0x1fb  2    RG   {8  8  0  0 } {8  8  0  0 } ivec2      rg8i      
    rg8s       SNORM  0x1fb  2    RG   {8  8  0  0 } {8  8  0  0 } vec2       rg8_snorm 
    rg8u       UINT   0x1fb  2    RG   {8  8  0  0 } {8  8  0  0 } uvec2      rg8ui     
    rgba8      UNORM  0x1fb  4    RGBA {8  8  8  8 } {8  8  8  8 } vec4       rgba8     
    rgba8i     SINT   0x1fb  4    RGBA {8  8  8  8 } {8  8  8  8 } ivec4      rgba8i    
    rgba8s     SNORM  0x1fb  4    RGBA {8  8  8  8 } {8  8  8  8 } vec4       rgba8_snorm
    rgba8u     UINT   0x1fb  4    RGBA {8  8  8  8 } {8  8  8  8 } uvec4      rgba8ui   
    r16        UNORM  0x1fb  2    R    {16 0  0  0 } {16 0  0  0 } float      r16       
    r16hf      FLOAT  0x1fb  2    R    {16 0  0  0 } {16 0  0  0 } float      r16f      
    r16i       SINT   0x1fb  2    R    {16 0  0  0 } {16 0  0  0 } int        r16i      
    r16s       SNORM  0x1fb  2    R    {16 0  0  0 } {16 0  0  0 } float      r16_snorm 
    r16u       UINT   0x1fb  2    R    {16 0  0  0 } {16 0  0  0 } uint       r16ui     
    rg16       UNORM  0x1fb  4    RG   {16 16 0  0 } {16 16 0  0 } vec2       rg16      
    rg16hf     FLOAT  0x1fb  4    RG   {16 16 0  0 } {16 16 0  0 } vec2       rg16f     
    rg16i      SINT   0x1fb  4    RG   {16 16 0  0 } {16 16 0  0 } ivec2      rg16i     
    rg16s      SNORM  0x1fb  4    RG   {16 16 0  0 } {16 16 0  0 } vec2       rg16_snorm
    rg16u      UINT   0x1fb  4    RG   {16 16 0  0 } {16 16 0  0 } uvec2      rg16ui    
    rgba16     UNORM  0x1fb  8    RGBA {16 16 16 16} {16 16 16 16} vec4       rgba16    
    rgba16hf   FLOAT  0x1fb  8    RGBA {16 16 16 16} {16 16 16 16} vec4       rgba16f   
    rgba16i    SINT   0x1fb  8    RGBA {16 16 16 16} {16 16 16 16} ivec4      rgba16i   
    rgba16s    SNORM  0x1fb  8    RGBA {16 16 16 16} {16 16 16 16} vec4       rgba16_snorm
    rgba16u    UINT   0x1fb  8    RGBA {16 16 16 16} {16 16 16 16} uvec4      rgba16ui  
    r32f       FLOAT  0x1fb  4    R    {32 0  0  0 } {32 0  0  0 } float      r32f      
    r32i       SINT   0x1fb  4    R    {32 0  0  0 } {32 0  0  0 } int        r32i      
    r32u       UINT   0x1fb  4    R    {32 0  0  0 } {32 0  0  0 } uint       r32ui     
    rg32f      FLOAT  0x1fb  8    RG   {32 32 0  0 } {32 32 0  0 } vec2       rg32f     
    rg32i      SINT   0x1fb  8    RG   {32 32 0  0 } {32 32 0  0 } ivec2      rg32i     
    rg32u      UINT   0x1fb  8    RG   {32 32 0  0 } {32 32 0  0 } uvec2      rg32ui    
    rgba32f    FLOAT  0x1fb  16   RGBA {32 32 32 32} {32 32 32 32} vec4       rgba32f   
    rgba32i    SINT   0x1fb  16   RGBA {32 32 32 32} {32 32 32 32} ivec4      rgba32i   
    rgba32u    UINT   0x1fb  16   RGBA {32 32 32 32} {32 32 32 32} uvec4      rgba32ui  
    a2bgr10    UNORM  0x1bb  4    ABGR {2  10 10 10} {2  10 10 10} vec4       rgb10_a2  
    a2bgr10u   UINT   0x1bb  4    ABGR {2  10 10 10} {2  10 10 10} uvec4      rgb10_a2ui
    bgra8      UNORM  0x1bb  4    BGRA {8  8  8  8 } {8  8  8  8 } vec4       rgba8     
    rgb8       UNORM  0x40   3    RGB  {8  8  8  0 } {8  8  8  0 } vec3                 
    rgb8i      SINT   0x40   3    RGB  {8  8  8  0 } {8  8  8  0 } ivec3                
    rgb8s      SNORM  0x40   3    RGB  {8  8  8  0 } {8  8  8  0 } vec3                 
    rgb8u      UINT   0x40   3    RGB  {8  8  8  0 } {8  8  8  0 } uvec3                
    rgb16      UNORM  0x40   6    RGB  {16 16 16 0 } {16 16 16 0 } vec3                 
    rgb16hf    FLOAT  0x40   6    RGB  {16 16 16 0 } {16 16 16 0 } vec3                 
    rgb16i     SINT   0x40   6    RGB  {16 16 16 0 } {16 16 16 0 } ivec3                
    rgb16s     SNORM  0x40   6    RGB  {16 16 16 0 } {16 16 16 0 } vec3                 
    rgb16u     UINT   0x40   6    RGB  {16 16 16 0 } {16 16 16 0 } uvec3                
    rgb32f     FLOAT  0x40   12   RGB  {32 32 32 0 } {32 32 32 0 } vec3                 
    rgb32i     SINT   0x40   12   RGB  {32 32 32 0 } {32 32 32 0 } ivec3                
    rgb32u     UINT   0x40   12   RGB  {32 32 32 0 } {32 32 32 0 } uvec3                
    a1rgb5     UNORM  0x0    2    ARGB {1  5  5  5 } {1  5  5  5 }                      
    a2rgb10    UNORM  0x0    4    ARGB {2  10 10 10} {2  10 10 10}                      
    a2rgb10i   SINT   0x0    4    ARGB {2  10 10 10} {2  10 10 10}                      
    a2rgb10s   SNORM  0x0    4    ARGB {2  10 10 10} {2  10 10 10}                      
    a2rgb10u   UINT   0x0    4    ARGB {2  10 10 10} {2  10 10 10}                      
    a2bgr10i   SINT   0x0    4    ABGR {2  10 10 10} {2  10 10 10}                      
    a2bgr10s   SNORM  0x0    4    ABGR {2  10 10 10} {2  10 10 10}                      
    rg4        UNORM  0x0    1    RG   {4  4  0  0 } {4  4  0  0 }                      
    rgba4      UNORM  0x0    2    RGBA {4  4  4  4 } {4  4  4  4 }                      
    bgra4      UNORM  0x0    2    BGRA {4  4  4  4 } {4  4  4  4 }                      
    rgb5a1     UNORM  0x0    2    RGBA {5  5  5  1 } {5  5  5  1 }                      
    rgb565     UNORM  0x0    2    RGB  {5  6  5  0 } {5  6  5  0 }                      
    bgr5a1     UNORM  0x0    2    BGRA {5  5  5  1 } {5  5  5  1 }                      
    bgr565     UNORM  0x0    2    BGR  {5  6  5  0 } {5  6  5  0 }                      
    bgr8       UNORM  0x0    3    BGR  {8  8  8  0 } {8  8  8  0 }                      
    bgr8i      SINT   0x0    3    BGR  {8  8  8  0 } {8  8  8  0 }                      
    bgr8u      UINT   0x0    3    BGR  {8  8  8  0 } {8  8  8  0 }                      
    bgra8i     SINT   0x0    4    BGRA {8  8  8  8 } {8  8  8  8 }                      
    bgra8u     UINT   0x0    4    BGRA {8  8  8  8 } {8  8  8  8 }                      
    abgr8      UNORM  0x0    4    ABGR {8  8  8  8 } {8  8  8  8 }                      
    abgr8i     SINT   0x0    4    ABGR {8  8  8  8 } {8  8  8  8 }                      
    abgr8s     SNORM  0x0    4    ABGR {8  8  8  8 } {8  8  8  8 }                      
    abgr8u     UINT   0x0    4    ABGR {8  8  8  8 } {8  8  8  8 }                      
    r64df      FLOAT  0x0    8    R    {64 0  0  0 } {64 0  0  0 }                      
    r64i       SINT   0x0    8    R    {64 0  0  0 } {64 0  0  0 }                      
    r64u       UINT   0x0    8    R    {64 0  0  0 } {64 0  0  0 }                      
    rg64df     FLOAT  0x0    16   RG   {64 64 0  0 } {64 64 0  0 }                      
    rg64i      SINT   0x0    16   RG   {64 64 0  0 } {64 64 0  0 }                      
    rg64u      UINT   0x0    16   RG   {64 64 0  0 } {64 64 0  0 }                      
    rgb64df    FLOAT  0x0    24   RGB  {64 64 64 0 } {64 64 64 0 }                      
    rgb64i     SINT   0x0    24   RGB  {64 64 64 0 } {64 64 64 0 }                      
    rgb64u     UINT   0x0    24   RGB  {64 64 64 0 } {64 64 64 0 }                      
    rgba64df   FLOAT  0x0    32   RGBA {64 64 64 64} {64 64 64 64}                      
    rgba64i    SINT   0x0    32   RGBA {64 64 64 64} {64 64 64 64}                      
    rgba64u    UINT   0x0    32   RGBA {64 64 64 64} {64 64 64 64}                      
Requested swap mode unsupported by this device, falling back to VK_PRESENT_MODE_FIFO_KHR
Failed picking any compatible texture format for a plane!
Failed uploading image plane!
```