### PR TITLE
Require meson 0.47

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('libplacebo', ['c', 'cpp'],
   license: 'LGPL2.1+',
   default_options: ['c_std=c99'],
+  meson_version: '>=0.47',
 )
 
 subdir('src')


### PR DESCRIPTION
Type 'feature' for get_option was introduced in meson 0.27, so require
it.