### PR TITLE
vulkan: Implement exporting of textures

### DIFF
--- a/src/include/libplacebo/vulkan.h
+++ b/src/include/libplacebo/vulkan.h
@@ -271,6 +271,17 @@ bool pl_vulkan_hold(const struct pl_gpu *gpu, const struct pl_tex *tex,
                     VkImageLayout layout, VkAccessFlags access,
                     VkSemaphore sem_out);
 
+// "Hold" a shared image for external use. This will transition the image into
+// a general layout and access mode, and the external queue. It will fire the
+// given semaphore (required!) when this is done. This marks the image as held.
+// Attempting to perform any pl_tex_* operation (except pl_tex_destroy) on a
+// held image is an error.
+//
+// Returns whether successful.
+bool pl_vulkan_hold_external(const struct pl_gpu *gpu,
+                             const struct pl_tex *tex,
+                             VkSemaphore sem_out);
+
 // "Release" a shared image, meaning it is no longer held. `layout` and
 // `access` describe the current state of the image at the point in time when
 // the user is releasing it. Performing any operation on the VkImage underlying
@@ -281,5 +292,12 @@ bool pl_vulkan_hold(const struct pl_gpu *gpu, const struct pl_tex *tex,
 void pl_vulkan_release(const struct pl_gpu *gpu, const struct pl_tex *tex,
                        VkImageLayout layout, VkAccessFlags access,
                        VkSemaphore sem_in);
+
+// "Release" a shared image from external use. This is a convenience wrapper
+// around `pl_vulkan_release` that automatically sets the layout and access
+// mode to those used for external sharing.
+void pl_vulkan_release_external(const struct pl_gpu *gpu,
+                                const struct pl_tex *tex,
+                                VkSemaphore sem_in);
 
 #endif // LIBPLACEBO_VULKAN_H_

--- a/src/vulkan/malloc.c
+++ b/src/vulkan/malloc.c
@@ -496,9 +496,10 @@ static bool slice_heap(struct vk_malloc *ma, struct vk_heap *heap, size_t size,
 }
 
 bool vk_malloc_generic(struct vk_malloc *ma, VkMemoryRequirements reqs,
-                       VkMemoryPropertyFlags flags, struct vk_memslice *out)
+                       VkMemoryPropertyFlags flags, pl_handle_types ext_handles,
+                       struct vk_memslice *out)
 {
-    struct vk_heap *heap = find_heap(ma, 0, flags, 0, &reqs);
+    struct vk_heap *heap = find_heap(ma, 0, flags, ext_handles, &reqs);
     return slice_heap(ma, heap, reqs.size, reqs.alignment, out);
 }
 

--- a/src/vulkan/malloc.h
+++ b/src/vulkan/malloc.h
@@ -39,7 +39,8 @@ struct vk_memslice {
 
 void vk_free_memslice(struct vk_malloc *ma, struct vk_memslice slice);
 bool vk_malloc_generic(struct vk_malloc *ma, VkMemoryRequirements reqs,
-                       VkMemoryPropertyFlags flags, struct vk_memslice *out);
+                       VkMemoryPropertyFlags flags, pl_handle_types ext_handles,
+                       struct vk_memslice *out);
 
 // Represents a single "slice" of a larger buffer
 struct vk_bufslice {


### PR DESCRIPTION
This is analogous to the existing functionality for buffers. A
texture may be created, requesting that it be exported. A
texture is transitioned between external and internal use with
pl_vulkan_hold (with export set to true) and pl_vulkan_release.