### PR TITLE
vulkan: Use VkExternalMemory[Buffer|Image]CreateInfo

### DIFF
--- a/src/vulkan/gpu.c
+++ b/src/vulkan/gpu.c
@@ -750,8 +750,20 @@ static const struct pl_tex *vk_tex_create(const struct pl_gpu *gpu,
     for (int i = 0; i < vk->num_pools; i++)
         qfs[i] = vk->pools[i]->qf;
 
+    VkExternalMemoryImageCreateInfoKHR ext_info = {
+        .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_KHR,
+        .handleTypes = 0,
+    };
+
+    switch (params->handle_type) {
+    case PL_HANDLE_FD:
+        ext_info.handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
+        break;
+    }
+
     VkImageCreateInfo iinfo = {
         .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .pNext = params->handle_type ? &ext_info : NULL,
         .imageType = tex_vk->type,
         .format = ifmt,
         .extent = (VkExtent3D) {

--- a/src/vulkan/malloc.c
+++ b/src/vulkan/malloc.c
@@ -158,9 +158,15 @@ static struct vk_slab *slab_alloc(struct vk_malloc *ma, struct vk_heap *heap,
         .handleTypes = 0,
     };
 
+    VkExternalMemoryBufferCreateInfoKHR ext_buf_info = {
+        .sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO_KHR,
+        .handleTypes = 0,
+    };
+
     switch (heap->handle_type) {
     case PL_HANDLE_FD:
         ext_info.handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
+        ext_buf_info.handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
         slab->handle_type = PL_HANDLE_FD;
         slab->handle.fd = -1;
         break;
@@ -184,6 +190,7 @@ static struct vk_slab *slab_alloc(struct vk_malloc *ma, struct vk_heap *heap,
 
         VkBufferCreateInfo binfo = {
             .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+            .pNext = heap->handle_type ? &ext_buf_info : NULL,
             .size  = slab->size,
             .usage = heap->usage,
             .sharingMode = vk->num_pools > 1 ? VK_SHARING_MODE_CONCURRENT


### PR DESCRIPTION
We have confirmed that these structs need to be used when creating an
image or buffer that will be backed by memory that will in turn be
exported for use with an external API.

https://github.com/KhronosGroup/Vulkan-Docs/issues/867