### PR TITLE
gpu: vulkan: Add support for win32 handle types

### DIFF
--- a/src/include/libplacebo/gpu.h
+++ b/src/include/libplacebo/gpu.h
@@ -57,15 +57,21 @@ enum {
 // communication of such an interoperation.
 typedef uint64_t pl_handle_caps;
 enum pl_handle_type {
-    PL_HANDLE_FD    = (1 << 0), // `int fd` for POSIX-style APIs
+    PL_HANDLE_FD        = (1 << 0), // `int fd` for POSIX-style APIs
+    PL_HANDLE_WIN32     = (1 << 1), // `HANDLE` for win32 API
+    PL_HANDLE_WIN32_KMT = (1 << 2), // `HANDLE` for pre-Windows-8 win32 API
 };
 
 // Wrapper for the handle used to communicate a shared resource externally.
 // This handle is owned by the `pl_gpu` - if a user wishes to use it in a way
 // that takes over ownership (e.g. importing into some APIs), they must clone
-// the handle before doing so (e.g. using `dup` for fds).
+// the handle before doing so (e.g. using `dup` for fds). It is important to
+// read the external API documentation _very_ carefully as different handle
+// types may be managed in different ways. (eg: CUDA takes ownership of an fd,
+// but does not take ownership of a win32 handle).
 union pl_handle {
     int fd;         // PL_HANDLE_FD
+    void *handle;   // PL_HANDLE_WIN32 / PL_HANDLE_WIN32_KMT
 };
 
 // Structure encapsulating memory that is shared between libplacebo and the

--- a/src/vulkan/common.h
+++ b/src/vulkan/common.h
@@ -24,6 +24,10 @@
 #define VK_HAVE_UNIX 1
 #endif
 
+#if defined(_WIN32)
+#define VK_HAVE_WIN32 1
+#endif
+
 // Vulkan allows the optional use of a custom allocator. We don't need one but
 // mark this parameter with a better name in case we ever decide to change this
 // in the future. (And to make the code more readable)
@@ -83,4 +87,8 @@ struct vk_ctx {
     VK_FUN(vkCmdPushDescriptorSetKHR);
     VK_FUN(vkGetMemoryFdKHR);
     VK_FUN(vkGetSemaphoreFdKHR);
+#ifdef VK_HAVE_WIN32
+    VK_FUN(vkGetMemoryWin32HandleKHR);
+    VK_FUN(vkGetSemaphoreWin32HandleKHR);
+#endif
 };

--- a/src/vulkan/context.c
+++ b/src/vulkan/context.c
@@ -62,6 +62,14 @@ static const struct vk_ext vk_device_extensions[] = {
             VK_DEV_FUN(vkGetMemoryFdKHR),
             {0},
         },
+#ifdef VK_HAVE_WIN32
+    }, {
+        .name = VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME,
+        .funs = (struct vk_ext_fun[]) {
+            VK_DEV_FUN(vkGetMemoryWin32HandleKHR),
+            {0},
+        },
+#endif
     }, {
         .name = VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
         .funs = (struct vk_ext_fun[]) {{0}},
@@ -71,6 +79,14 @@ static const struct vk_ext vk_device_extensions[] = {
             VK_DEV_FUN(vkGetSemaphoreFdKHR),
             {0},
         },
+#ifdef VK_HAVE_WIN32
+    }, {
+        .name = VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME,
+        .funs = (struct vk_ext_fun[]) {
+            VK_DEV_FUN(vkGetSemaphoreWin32HandleKHR),
+            {0},
+        },
+#endif
     }
 };
 

--- a/src/vulkan/gpu.c
+++ b/src/vulkan/gpu.c
@@ -220,9 +220,13 @@ static pl_handle_caps vk_sync_handle_caps(struct vk_ctx *vk)
 {
     pl_handle_caps ret = 0;
 
-#if VK_HAVE_UNIX
+#ifdef VK_HAVE_UNIX
     if (vk->vkGetSemaphoreFdKHR)
         ret |= PL_HANDLE_FD;
+#endif
+#ifdef VK_HAVE_WIN32
+    if (vk->vkGetSemaphoreWin32HandleKHR)
+        ret |= (PL_HANDLE_WIN32 | PL_HANDLE_WIN32_KMT)
 #endif
 
     return ret;
@@ -758,6 +762,12 @@ static const struct pl_tex *vk_tex_create(const struct pl_gpu *gpu,
     switch (params->handle_type) {
     case PL_HANDLE_FD:
         ext_info.handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
+        break;
+    case PL_HANDLE_WIN32:
+        ext_info.handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR;
+        break;
+    case PL_HANDLE_WIN32_KMT:
+        ext_info.handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR;
         break;
     }
 
@@ -2500,6 +2510,15 @@ static void vk_sync_destroy(const struct pl_gpu *gpu, struct pl_sync *sync)
             close(sync->signal_handle.fd);
     }
 #endif
+#ifdef VK_HAVE_WIN32
+    if (slab->handle_type == PL_HANDLE_WIN32) {
+        if (sync->wait_handle.handle != NULL)
+            CloseHandle(sync->wait_handle.handle);
+        if (sync->signal_handle.handle != NULL)
+            CloseHandle(sync->signal_handle.handle);
+    }
+    // PL_HANDLE_WIN32_KMT is just an identifier. It doesn't get closed.
+#endif
 
     vkDestroySemaphore(vk->dev, sync_vk->wait, VK_ALLOC);
     vkDestroySemaphore(vk->dev, sync_vk->signal, VK_ALLOC);
@@ -2539,6 +2558,16 @@ static const struct pl_sync *vk_sync_create(const struct pl_gpu *gpu,
         sync->wait_handle.fd = -1;
         sync->signal_handle.fd = -1;
         break;
+    case PL_HANDLE_WIN32:
+        einfo.handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR;
+        sync->wait_handle.handle = NULL;
+        sync->signal_handle.handle = NULL;
+        break;
+    case PL_HANDLE_WIN32_KMT:
+        einfo.handleTypes |= VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR;
+        sync->wait_handle.handle = NULL;
+        sync->signal_handle.handle = NULL;
+        break;
     }
 
     const VkSemaphoreCreateInfo sinfo = {
@@ -2560,6 +2589,27 @@ static const struct pl_sync *vk_sync_create(const struct pl_gpu *gpu,
 
         finfo.semaphore = sync_vk->signal;
         VK(vk->vkGetSemaphoreFdKHR(vk->dev, &finfo, &sync->signal_handle.fd));
+    }
+#endif
+#ifdef VK_HAVE_WIN32
+    VkExternalSemaphoreHandleTypeFlagBits handle_type = 0;
+    if (slab->handle_type == PL_HANDLE_WIN32) {
+        handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR;
+    } else if (slab->handle_type == PL_HANDLE_WIN32_KMT) {
+        handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR;
+    }
+    if (handle_type) {
+        VkSemaphoreGetWin32HandleInfoKHR handle_info = {
+            .sType = VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR,
+            .semaphore = sync_vk->wait,
+            .handleType = handle_type,
+        };
+        VK(vk->vkGetSemaphoreWin32HandleKHR(vk->dev, &handle_info,
+                                            &sync->wait_handle.handle));
+
+        handle_info.semaphore = sync_vk->signal;
+        VK(vk->vkGetSemaphoreWin32HandleKHR(vk->dev, &handle_info,
+                                            &sync->signal_handle.handle));
     }
 #endif
 


### PR DESCRIPTION
There are two win32 specific handle types, which we believe to be
the ones that would be primarily used by a win32 client.

There is the 'NT Handle', which is available on Windows 8 or newer,
and the 'Global share Handle' (abbreviated as KMT in the Vulkan spec),
which is available on Windows 7 and newer, but which apparently
shouldn't be used when the 'NT Handle' type is available. We do not
attempt to judge usage, and it is up to the client to decide which
of the two types it wants to use.

Note that the existing logic for identifying the handle_caps is not
actually sufficient. We need to call specific functions to identify
what is possible for buffers, images, and semaphores.

* vkGetPhysicalDeviceImageFormatProperties2KHR
* vkGetPhysicalDeviceExternalBufferPropertiesKHR
* vkGetPhysicalDeviceExternalSemaphorePropertiesKHR

and these need to be called with the specific flags and parameters,
so I think it basically ends up being that you can't tell if your
image/buffer/semaphore is exportable until you create it. Anyway.

I am not in a position to test any of these changes. Someone who
can build on win32 must do that.