### PR TITLE
opengl: fix argument type for tex in gl_tex_{im,ex}port

### DIFF
--- a/src/opengl/gpu.c
+++ b/src/opengl/gpu.c
@@ -692,13 +692,13 @@ error:
 
 static bool gl_tex_import(pl_gpu gpu, enum pl_handle_type handle_type,
                           const struct pl_shared_mem *shared_mem,
-                          struct pl_tex tex)
+                          struct pl_tex *tex)
 {
     abort(); // no implementations
 }
 
 static bool gl_tex_export(pl_gpu gpu, enum pl_handle_type handle_type,
-                          bool preserved, struct pl_tex tex)
+                          bool preserved, struct pl_tex *tex)
 {
     abort(); // no implementations
 }


### PR DESCRIPTION
fixes an issue where one implementation has
```c
static bool gl_tex_import(pl_gpu gpu,
                          enum pl_handle_type handle_type,
                          const struct pl_shared_mem *shared_mem,
                          struct pl_tex *tex)
```
and the other has
```c
static bool gl_tex_import(pl_gpu gpu, enum pl_handle_type handle_type,
                          const struct pl_shared_mem *shared_mem,
                          struct pl_tex tex)
```
and causes an error such as
```c
../src/opengl/gpu.c:765:77: error: incompatible type for argument 4 of 'gl_tex_import'
  765 |         if (!gl_tex_import(gpu, params->import_handle, &params->shared_mem, tex))
      |                                                                             ^~~
      |                                                                             |
      |                                                                             struct pl_tex *
../src/opengl/gpu.c:695:41: note: expected 'struct pl_tex' but argument is of type 'struct pl_tex *'
  695 |                           struct pl_tex tex)
```