### PR TITLE
libav_internal: include libavutil/hwcontext_vulkan.h

### DIFF
--- a/src/include/libplacebo/utils/libav_internal.h
+++ b/src/include/libplacebo/utils/libav_internal.h
@@ -35,6 +35,7 @@
 
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 8, 100)
 # define HAVE_LAV_VULKAN
+# include <libavutil/hwcontext_vulkan.h>
 # include <libplacebo/vulkan.h>
 #endif
 


### PR DESCRIPTION
fixes
```c
include/libplacebo/utils/libav_internal.h: In function 'pl_map_avframe_vulkan':
include/libplacebo/utils/libav_internal.h:862:11: error: unknown type name 'AVVulkanFramesContext'
  862 |     const AVVulkanFramesContext *vkfc = hwfc->hwctx;
```

that occurs while building mpv on windows with mingw-w64 gcc, there are a few more errors, but it would make this description too long.