### PR TITLE
meson: fix check for execinfo.h usability

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -77,13 +77,14 @@ if d3d11_found
 endif
 
 unwind = dependency('libunwind', required: get_option('unwind'))
-has_execinfo = cc.has_header('execinfo.h')
+libexecinfo = cc.find_library('execinfo', required: false)
+has_execinfo = cc.has_function('backtrace_symbols', dependencies: libexecinfo, prefix: '#include <execinfo.h>')
 conf_internal.set('PL_HAVE_UNWIND', unwind.found())
 conf_internal.set('PL_HAVE_EXECINFO', has_execinfo)
 if unwind.found()
   build_deps += [unwind, cc.find_library('dl', required : false)]
 elif has_execinfo
-  build_deps += cc.find_library('execinfo', required: false)
+  build_deps += libexecinfo
 endif
 
 # work-arounds for glslang braindeath


### PR DESCRIPTION
recent Android has execinfo.h but whether it actually defines any functions depends on the API level of the current build.