### PR TITLE
opengl: don't try to use libdl on *BSD OS's

### DIFF
--- a/src/opengl/meson.build
+++ b/src/opengl/meson.build
@@ -1,7 +1,8 @@
 opengl_build = get_option('opengl')
 opengl_link = get_option('gl-proc-addr')
 
-if host_machine.system() == 'windows'
+if host_machine.system() == 'windows' or host_machine.system().endswith('bsd') or \
+   host_machine.system() == 'dragonfly'
     libdl = declare_dependency()
 else
     libdl = cc.find_library('dl', required : opengl_link)


### PR DESCRIPTION
As mentioned in https://github.com/haasn/libplacebo/issues/147 there is a
better way of doing this with newer Meson, but for a greater level of
backwards compatibility just use the same style as is already there.