### PR TITLE
renderer: fix memory leak of pass.tmp

### DIFF
--- a/src/renderer.c
+++ b/src/renderer.c
@@ -2949,7 +2949,6 @@ bool pl_render_image_mix(pl_renderer rr, const struct pl_frame_mix *images,
     struct cached_frame frames[MAX_MIX_FRAMES];
     float weights[MAX_MIX_FRAMES];
     float wsum = 0.0;
-    pass.tmp = pl_tmp(NULL);
 
     // Garbage collect the cache by evicting all frames from the cache that are
     // not determined to still be required


### PR DESCRIPTION
~Commit [0] added a reallocation of render_pass.tmp on reuse of the struct. The object presiously pointed to by this field was not free however, leading to a memory leak of 32 bytes everytime the reallocation was execute.~

~Free the previously allocated object to fix this issue.~

Remove unnecessry allocation of `render_pass.tmp`.
    
When commit [0] added this reallocation of render_pass.tmp for reuse of
the struct it was still necessary to do so.
Down the line `pass_init()` was introduced which also allocates the
field tmp.
The object presiously pointed to by this field was not freed however,
leading to a memory leak of 32 bytes everytime the reallocation was
executed.
    
Remove the explicit allocation to fix the leak.

[0] eeed2d7f3999 ("renderer: fix several bugs related to pl_render_image reuse")