### PR TITLE
String templates v2

### DIFF
--- a/src/pl_string.c
+++ b/src/pl_string.c
@@ -26,15 +26,19 @@ static void grow_str(void *alloc, pl_str *str, size_t len)
 
 void pl_str_append(void *alloc, pl_str *str, pl_str append)
 {
-    if (!append.len)
-        return;
-
     // Also append an extra \0 for convenience, since a lot of the time
     // this function will be used to generate a string buffer
     grow_str(alloc, str, str->len + append.len + 1);
     memcpy(str->buf + str->len, append.buf, append.len);
     str->len += append.len;
     str->buf[str->len] = '\0';
+}
+
+void pl_str_append_raw(void *alloc, pl_str *str, const void *ptr, size_t size)
+{
+    grow_str(alloc, str, str->len + size);
+    memcpy(str->buf + str->len, ptr, size);
+    str->len += size;
 }
 
 void pl_str_append_asprintf(void *alloc, pl_str *str, const char *fmt, ...)

--- a/src/pl_string.c
+++ b/src/pl_string.c
@@ -231,3 +231,171 @@ error:
     pl_free(buf);
     return false;
 }
+
+struct pl_str_builder_t {
+    PL_ARRAY(pl_str_template) templates;
+    pl_str args;
+    pl_str output;
+};
+
+pl_str_builder pl_str_builder_alloc(void *alloc)
+{
+    pl_str_builder b = pl_zalloc_ptr(alloc, b);
+    return b;
+}
+
+void pl_str_builder_free(pl_str_builder *b)
+{
+    if (*b)
+        pl_free_ptr(b);
+}
+
+void pl_str_builder_reset(pl_str_builder b)
+{
+    *b = (struct pl_str_builder_t) {
+        .templates.elem = b->templates.elem,
+        .args.buf       = b->args.buf,
+        .output.buf     = b->output.buf,
+    };
+}
+
+uint64_t pl_str_builder_hash(const pl_str_builder b)
+{
+    size_t size = b->templates.num * sizeof(b->templates.elem[0]);
+    uint64_t hash = pl_mem_hash(b->templates.elem, size);
+    pl_hash_merge(&hash, pl_str_hash(b->args));
+    return hash;
+}
+
+pl_str pl_str_builder_exec(pl_str_builder b)
+{
+    pl_str args = b->args;
+
+    b->output.len = 0;
+    for (int i = 0; i < b->templates.num; i++) {
+        size_t consumed = b->templates.elem[i](b, &b->output, args.buf);
+        pl_assert(consumed <= args.len);
+        args = pl_str_drop(args, consumed);
+    }
+
+    // Terminate with an extra \0 byte for convenience
+    grow_str(b, &b->output, b->output.len + 1);
+    b->output.buf[b->output.len] = '\0';
+    return b->output;
+}
+
+void pl_str_builder_append(pl_str_builder b, pl_str_template tmpl,
+                           const void *args, size_t size)
+{
+    PL_ARRAY_APPEND(b, b->templates, tmpl);
+    pl_str_append_raw(b, &b->args, args, size);
+}
+
+void pl_str_builder_concat(pl_str_builder b, const pl_str_builder append)
+{
+    PL_ARRAY_CONCAT(b, b->templates, append->templates);
+    pl_str_append_raw(b, &b->args, append->args.buf, append->args.len);
+}
+
+static size_t template_str_ptr(void *alloc, pl_str *buf, const void *args)
+{
+    const char * const *ptr = args;
+    pl_str_append_raw(alloc, buf, *ptr, strlen(*ptr));
+    return sizeof(*ptr);
+}
+
+void pl_str_builder_const_str(pl_str_builder b, const char *str)
+{
+    pl_str_builder_append(b, template_str_ptr, &str, sizeof(str));
+}
+
+struct str_arg {
+    size_t len;
+    uint8_t start[];
+};
+
+static size_t template_str(void *alloc, pl_str *buf, const void *args)
+{
+    const struct str_arg *arg = args;
+    pl_str_append_raw(alloc, buf, arg->start, arg->len);
+    return sizeof(*arg) + arg->len;
+}
+
+void pl_str_builder_str(pl_str_builder b, const pl_str str)
+{
+    struct str_arg arg = {
+        .len = str.len,
+    };
+
+    // Construct a `str_arg` struct inside `b->args` without actually
+    // constructing it by first appending an empty `str_arg` and then
+    // appending the pl_str directly into the args list.
+    pl_str_builder_append(b, template_str, &arg, sizeof(arg));
+    pl_str_append_raw(b, &b->args, str.buf, str.len);
+}
+
+void pl_str_builder_printf_c(pl_str_builder b, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    pl_str_builder_vprintf_c(b, fmt, ap);
+    va_end(ap);
+}
+
+static size_t template_printf(void *alloc, pl_str *str, const void *args)
+{
+    const char * const *ptr = args;
+    return sizeof(*ptr) + pl_str_append_memprintf_c(alloc, str, *ptr, ptr + 1);
+}
+
+void pl_str_builder_vprintf_c(pl_str_builder b, const char *fmt, va_list ap)
+{
+    pl_str_builder_append(b, template_printf, &fmt, sizeof(fmt));
+
+    // Push all of the variadic arguments directly onto `b->args`
+    for (const char *c; (c = strchr(fmt, '%')) != NULL; fmt = c + 1) {
+        c++;
+        switch (c[0]) {
+#define WRITE(T, x) pl_str_append_raw(b, &b->args, &(T) {x}, sizeof(T))
+        case '%': continue;
+        case 'c': WRITE(char,       va_arg(ap, int)); break;
+        case 'd': WRITE(int,        va_arg(ap, int)); break;
+        case 'u': WRITE(unsigned,   va_arg(ap, unsigned)); break;
+        case 'f': WRITE(double,     va_arg(ap, double)); break;
+        case 'l':
+            assert(c[1] == 'l');
+            switch (c[2]) {
+            case 'u': WRITE(long long unsigned, va_arg(ap, long long unsigned)); break;
+            case 'd': WRITE(long long int,      va_arg(ap, long long int)); break;
+            default: abort();
+            }
+            c += 2;
+            break;
+        case 'z':
+            assert(c[1] == 'u');
+            WRITE(size_t, va_arg(ap, size_t));
+            c++;
+            break;
+        case 's': {
+            pl_str str = pl_str0(va_arg(ap, const char *));
+            pl_str_append(b, &b->args, str);
+            b->args.len++; // expand to include \0 byte (from pl_str_append)
+            break;
+        }
+        case '.': {
+            assert(c[1] == '*');
+            assert(c[2] == 's');
+            int len = va_arg(ap, int);
+            const char *str = va_arg(ap, const char *);
+            WRITE(int, len);
+            pl_str_append_raw(b, &b->args, str, len);
+            c += 2;
+            break;
+        }
+        default:
+            fprintf(stderr, "Invalid conversion character: '%c'!\n", c[0]);
+            abort();
+        }
+#undef WRITE
+    }
+}

--- a/src/pl_string.h
+++ b/src/pl_string.h
@@ -78,6 +78,21 @@ void pl_str_append_asprintf_c(void *alloc, pl_str *str, const char *fmt, ...)
 void pl_str_append_vasprintf_c(void *alloc, pl_str *str, const char *fmt, va_list va)
     PL_PRINTF(3, 0);
 
+// Variant of the above which takes arguments directly from a pointer in memory,
+// reading them incrementally (tightly packed). Returns the amount of bytes
+// read from `args`, as determined by the following table:
+//
+// %c: sizeof(char)
+// %d, %u: sizeof(int)
+// %f: sizeof(double)
+// %lld, %llu: sizeof(long long int)
+// %zu: sizeof(size_t)
+// %s: \0 terminated string
+// %.*s: sizeof(int) + that many bytes (no \0 terminator)
+size_t pl_str_append_memprintf_c(void *alloc, pl_str *str, const char *fmt,
+                                 const void *args)
+    PL_PRINTF(3, 0);
+
 // Locale-invariant number parsing
 bool pl_str_parse_double(pl_str str, double *out);
 bool pl_str_parse_int64(pl_str str, int64_t *out);

--- a/src/pl_string.h
+++ b/src/pl_string.h
@@ -259,3 +259,77 @@ static inline bool pl_str_eatend0(pl_str *str, const char *prefix)
 {
     return pl_str_eatend(str, pl_str0(prefix));
 }
+
+// String building helpers, used to lazily construct a string by appending a
+// series of string templates which can be executed on-demand into a final
+// output buffer.
+typedef struct pl_str_builder_t *pl_str_builder;
+
+// Returns the number of bytes consumed from `args`
+typedef size_t (*pl_str_template)(void *alloc, pl_str *buf, const void *args);
+
+pl_str_builder pl_str_builder_alloc(void *alloc);
+void pl_str_builder_free(pl_str_builder *builder);
+
+// Resets string builder without destroying buffer
+void pl_str_builder_reset(pl_str_builder builder);
+
+// Returns a representative hash of the string builder's output, without
+// actually executing it. Note that this is *not* the same as a pl_str_hash of
+// the string builder's output.
+//
+// Note also that the output of this may not survive a process restart because
+// of position-independent code and address randomization moving around the
+// locatons of template functions, so special care must be taken not to
+// compare such hashes across process invocations.
+uint64_t pl_str_builder_hash(const pl_str_builder builder);
+
+// Executes a string builder, dispatching all templates. The resulting string
+// is guaranteed to be \0-terminated, as a minor convenience.
+//
+// Calling any other `pl_str_builder_*` function on this builder causes the
+// contents of the returned string to become undefined.
+pl_str pl_str_builder_exec(pl_str_builder builder);
+
+// Append a template and its arguments to a string builder
+void pl_str_builder_append(pl_str_builder builder, pl_str_template tmpl,
+                           const void *args, size_t args_size);
+
+// Append an entire other `pl_str_builder` onto `builder`
+void pl_str_builder_concat(pl_str_builder builder, const pl_str_builder append);
+
+// Append a constant string. This will only record &str into the buffer, which
+// may have a number of unwanted consequences if the memory pointed at by
+// `str` mutates at any point in time in the future, or if `str` is not
+// at a stable location in memory.
+//
+// This is intended for strings which are compile-time constants.
+void pl_str_builder_const_str(pl_str_builder builder, const char *str);
+
+// Append a string. This will make a full copy of `str`
+void pl_str_builder_str(pl_str_builder builder, const pl_str str);
+#define pl_str_builder_str0(b, str) pl_str_builder_str(b, pl_str0(str))
+
+// Append a string printf-style. This will preprocess `fmt` to determine the
+// number and type of arguments. Supports the same format conversion characters
+// as `pl_str_append_asprintf_c`.
+void pl_str_builder_printf_c(pl_str_builder builder, const char *fmt, ...)
+    PL_PRINTF(2, 3);
+
+void pl_str_builder_vprintf_c(pl_str_builder builder, const char *fmt, va_list ap)
+    PL_PRINTF(2, 0);
+
+// Helper macro to specialize `pl_str_builder_printf_c` to
+// `pl_str_builder_const_str` if it contains no format characters.
+#define pl_str_builder_addf(builder, ...) do                                    \
+{                                                                               \
+    if (_contains_fmt_chars(__VA_ARGS__)) {                                     \
+        pl_str_builder_printf_c(builder, __VA_ARGS__);                          \
+    } else {                                                                    \
+        pl_str_builder_const_str(builder, _get_fmt(__VA_ARGS__));               \
+    }                                                                           \
+} while (0)
+
+// Helper macros to deal with the non-portability of __VA_OPT__(,)
+#define _contains_fmt_chars(fmt, ...)   (strchr(fmt, '%'))
+#define _get_fmt(fmt, ...)              fmt

--- a/src/pl_string.h
+++ b/src/pl_string.h
@@ -52,7 +52,11 @@ static inline char *pl_strdup0(void *alloc, pl_str str)
     return pl_strndup0(alloc, str.len ? (char *) str.buf : "", str.len);
 }
 
+// Adds a trailing \0 for convenience
 void pl_str_append(void *alloc, pl_str *str, pl_str append);
+
+// Like `pl_str_append` but for raw memory, omits trailing \0
+void pl_str_append_raw(void *alloc, pl_str *str, const void *ptr, size_t size);
 
 // Locale-sensitive string functions
 char *pl_asprintf(void *parent, const char *fmt, ...)

--- a/src/shaders.h
+++ b/src/shaders.h
@@ -54,7 +54,7 @@ struct pl_shader_t {
     int output_w;
     int output_h;
     bool transpose;
-    pl_str buffers[SH_BUF_COUNT];
+    pl_str_builder buffers[SH_BUF_COUNT];
     enum pl_shader_type type;
     bool flexible_work_groups;
     enum pl_sampler_type sampler_type;
@@ -143,10 +143,11 @@ size_t sh_buf_desc_size(const struct pl_shader_desc *buf_desc);
 
 
 // Underlying function for appending text to a shader
-void sh_append(pl_shader sh, enum pl_shader_buf buf, const char *fmt, ...)
-    PL_PRINTF(3, 4);
+#define sh_append(sh, buf, ...) \
+    pl_str_builder_addf((sh)->buffers[buf], __VA_ARGS__)
 
-void sh_append_str(pl_shader sh, enum pl_shader_buf buf, pl_str str);
+#define sh_append_str(sh, buf, str) \
+    pl_str_builder_str((sh)->buffers[buf], str)
 
 #define GLSLP(...) sh_append(sh, SH_BUF_PRELUDE, __VA_ARGS__)
 #define GLSLH(...) sh_append(sh, SH_BUF_HEADER, __VA_ARGS__)

--- a/src/shaders.h
+++ b/src/shaders.h
@@ -69,6 +69,10 @@ struct pl_shader_t {
     PL_ARRAY(const char *) steps;
 };
 
+// Same as `pl_shader_finalize` but doesn't template `sh->res.glsl`, instead
+// returns the string builder to be used to finalize the shader.
+pl_str_builder sh_finalize_internal(pl_shader sh);
+
 // Helper functions for convenience
 #define SH_PARAMS(sh) ((sh)->res.params)
 #define SH_GPU(sh) (SH_PARAMS(sh).gpu)

--- a/src/shaders/lut.c
+++ b/src/shaders/lut.c
@@ -659,7 +659,7 @@ next_dim: ; // `continue` out of the inner loop
         GLSLH("const %s %s[%d] = %s[](\n  ",
               vartypes[vartype][params->comps - 1], arr_name, size,
               vartypes[vartype][params->comps - 1]);
-        pl_str_append(sh, &sh->buffers[SH_BUF_HEADER], lut->str);
+        sh_append_str(sh, SH_BUF_HEADER, lut->str);
         GLSLH(");\n");
         break;
 

--- a/src/tests/string.c
+++ b/src/tests/string.c
@@ -111,6 +111,19 @@ int main()
     REQUIRE(!pl_str_parse_uint(test, &u));
     REQUIRE(!pl_str_parse_uint(empty, &u));
 
+    pl_str_builder builder = pl_str_builder_alloc(tmp);
+    pl_str_builder_const_str(builder, "hello");
+    pl_str_builder_str(builder, pl_str0("world"));
+    pl_str res = pl_str_builder_exec(builder);
+    REQUIRE(pl_str_equals0(res, "helloworld"));
+
+    pl_str_builder_reset(builder);
+    pl_str_builder_printf_c(builder, "foo %d bar %u bat %s baz %lld",
+            123, 56u, "quack", 0xDEADBEEFll);
+    pl_str_builder_printf_c(builder, " %.*s", PL_STR_FMT(pl_str0("test123")));
+    res = pl_str_builder_exec(builder);
+    REQUIRE(pl_str_equals0(res, "foo 123 bar 56 bat quack baz 3735928559 test123"));
+
     pl_free(tmp);
     return 0;
 }

--- a/src/tests/string.c
+++ b/src/tests/string.c
@@ -26,7 +26,7 @@ int main()
 
     pl_str buf = {0};
     pl_str_append(tmp, &buf, null);
-    REQUIRE(is_null(buf));
+    REQUIRE(is_empty(buf));
     pl_str_append_asprintf(tmp, &buf, "%.*s", PL_STR_FMT(test));
     REQUIRE(pl_str_equals(buf, test));
 


### PR DESCRIPTION
Partial solution for the string concatenation problem.

What this PR does:
- define new helper `pl_str_builder` which can be used to cheaply concatenate a list of *templates*, plus their corresponding arguments
- use `pl_str_builder` instead of `pl_str` for generating shaders inside `pl_shader` and `pl_dispatch`
- use a (relatively cheaper) hash of the `pl_str_builder` (list of templates + args) to look up programs in the dispatch cache
- make `pl_dispatch` defer execution of the `pl_str_builder` (i.e. formatting the actual strings) until it's strictly necessary
- use a preprocessor macro to avoid `printf()` overhead for pure constant strings without format specifiers

This series ended up defining a very general, flexible string builder, one which we can easily expand on and build upon in the future. For example, it would be easy to move some of the more expensive shader operations (such as generating unrolled polar filter kernels) into a dedicated `pl_str_template` function which receives as input only the relevant arguments.

But in the long term, I want to use this abstraction as the staging grounds for more dedicated GLSL templating syntax, in the spirit of e.g. https://code.videolan.org/videolan/libplacebo/-/merge_requests/369#note_370145