### PR TITLE
pl_clock: use correct clock_id on apple platforms

### DIFF
--- a/src/pl_clock.h
+++ b/src/pl_clock.h
@@ -31,11 +31,11 @@
      (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 100000) || \
      (defined(__TV_OS_VERSION_MIN_REQUIRED)     && __TV_OS_VERSION_MIN_REQUIRED     < 100000) || \
      (defined(__WATCH_OS_VERSION_MIN_REQUIRED)  && __WATCH_OS_VERSION_MIN_REQUIRED  < 30000)  || \
-     !defined(CLOCK_MONOTONIC_RAW)
+     !defined(CLOCK_UPTIME_RAW)
 #  include <mach/mach_time.h>
 #  define PL_CLOCK_MACH
 # else
-#  define PL_CLOCK_MONOTONIC_RAW
+#  define PL_CLOCK_UPTIME_RAW
 # endif
 #elif defined(CLOCK_MONOTONIC_RAW)
 # define PL_CLOCK_MONOTONIC_RAW
@@ -64,6 +64,8 @@ static inline pl_clock_t pl_clock_now(void)
     struct timespec tp = { .tv_sec = 0, .tv_nsec = 0 };
 #if defined(PL_CLOCK_MONOTONIC_RAW)
     clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
+#elif defined(PL_CLOCK_UPTIME_RAW)
+    clock_gettime(CLOCK_UPTIME_RAW, &tp);
 #elif defined(PL_CLOCK_TIMESPEC_GET)
     timespec_get(&tp, TIME_UTC);
 #endif


### PR DESCRIPTION
CLOCK_MONOTONIC_RAW on apple platforms is a monotonic clock that gets incremented while system is suspended, the clock_id that should actually be used is CLOCK_UPTIME_RAW, this clock does not get incremented while system is suspended and matches time value of mach_absolute_time but with timebase ratio applied, so returned time is in nano seconds.

Fixes discrepancy with PL_CLOCK_MACH path.

See: https://github.com/apple-oss-distributions/Libc/blob/c5a3293354e22262702a3add5b2dfc9bb0b93b85/gen/clock_gettime.c#L168