### PR TITLE
vulkan/utils_gen: fix deprecation warning

### DIFF
--- a/src/vulkan/utils_gen.py
+++ b/src/vulkan/utils_gen.py
@@ -105,7 +105,7 @@ def get_vkstructs(registry):
                 stype = m
                 break
 
-        if stype and 'values' in stype.attrib:
+        if stype is not None and 'values' in stype.attrib:
             yield Obj(stype = stype.attrib['values'],
                       name = t.attrib['name'])
 


### PR DESCRIPTION
Fixes a deprecation warning when building with Python 3.12:
```
DeprecationWarning: Testing an element's truth value will raise an exception in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if stype and 'values' in stype.attrib:
```