### PR TITLE
filters: Add Power of Blackman and Power of Garamond windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ project('libplacebo', ['c', 'cpp'],
     7,
     # API version
     {
+      '342': 'add pl_filter_function_garamond',
       '341': 're-add pl_filter_function_{bicubic,bcspline,catmull_rom,mitchell,robidoux,robidouxsharp} as deprecated',
       '340': 'add pl_queue_params.drift_compensation, PL_QUEUE_DEFAULTS and pl_queue_pts_offset',
       '339': 'add pl_peak_detect_params.black_cutoff',

--- a/src/filters.c
+++ b/src/filters.c
@@ -399,6 +399,22 @@ const struct pl_filter_function pl_filter_function_gaussian = {
     .tunable   = {true},
 };
 
+//Power of Garamond window
+static double garamond(const struct pl_filter_ctx *f, double x)
+{
+    double n = f->params[0];
+    double m = f->params[1];
+    return pow(1.0 - pow(x, n), m);
+}
+
+const struct pl_filter_function pl_filter_function_garamond = {
+    .name    = "garamond",
+    .weight  = garamond,
+    .radius  = 1.0,
+    .params  = {2.0, 1.0},
+    .tunable = {true, true},
+};
+
 static double quadratic(const struct pl_filter_ctx *f, double x)
 {
     if (x < 0.5) {
@@ -623,6 +639,7 @@ const struct pl_filter_function * const pl_filter_functions[] = {
     &pl_filter_function_blackman,
     &pl_filter_function_bohman,
     &pl_filter_function_gaussian,
+    &pl_filter_function_garamond,
     &pl_filter_function_quadratic,
     &filter_function_quadric, // alias
     &pl_filter_function_sinc,
@@ -999,6 +1016,7 @@ const struct pl_filter_function_preset pl_filter_function_presets[] = {
     {"blackman",        &pl_filter_function_blackman},
     {"bohman",          &pl_filter_function_bohman},
     {"gaussian",        &pl_filter_function_gaussian},
+    {"garamond",        &pl_filter_function_garamond},
     {"quadratic",       &pl_filter_function_quadratic},
     {"quadric",         &filter_function_quadric}, // alias
     {"sinc",            &pl_filter_function_sinc},

--- a/src/filters.c
+++ b/src/filters.c
@@ -357,20 +357,22 @@ const struct pl_filter_function pl_filter_function_kaiser = {
     .tunable = {true},
 };
 
+//Power of Blackman window
 static double blackman(const struct pl_filter_ctx *f, double x)
 {
     double a = f->params[0];
-    double a0 = (1 - a) / 2.0, a1 = 1 / 2.0, a2 = a / 2.0;
+    double n = f->params[1];
+    double a0 = (1.0 - a) / 2.0, a1 = 1.0 / 2.0, a2 = a / 2.0;
     x *= M_PI;
-    return a0 + a1 * cos(x) + a2 * cos(2 * x);
+    return pow(a0 + a1 * cos(x) + a2 * cos(2.0 * x), n);
 }
 
 const struct pl_filter_function pl_filter_function_blackman = {
     .name    = "blackman",
     .weight  = blackman,
     .radius  = 1.0,
-    .params  = {0.16},
-    .tunable = {true},
+    .params  = {0.16, 1.0},
+    .tunable = {true, true},
 };
 
 static double bohman(const struct pl_filter_ctx *f, double x)

--- a/src/filters.c
+++ b/src/filters.c
@@ -361,7 +361,7 @@ const struct pl_filter_function pl_filter_function_kaiser = {
 static double blackman(const struct pl_filter_ctx *f, double x)
 {
     double a = f->params[0];
-    double n = f->params[1];
+    double n = fmax(f->params[1], 0.0);
 
     // Power of Blackman function may not be defined for all
     // x when alpha (a) is larger than 0.16, so in that case

--- a/src/filters.c
+++ b/src/filters.c
@@ -404,8 +404,10 @@ const struct pl_filter_function pl_filter_function_gaussian = {
 //Power of Garamond window
 static double garamond(const struct pl_filter_ctx *f, double x)
 {
-    double n = f->params[0];
-    double m = f->params[1];
+    double n = fmax(f->params[0], 0.0);
+    double m = fmax(f->params[1], 0.0);
+    if (n < 1e-8)
+        return 1.0;
     return pow(1.0 - pow(x, n), m);
 }
 

--- a/src/filters.c
+++ b/src/filters.c
@@ -357,11 +357,18 @@ const struct pl_filter_function pl_filter_function_kaiser = {
     .tunable = {true},
 };
 
-//Power of Blackman window
+// Power of Blackman window
 static double blackman(const struct pl_filter_ctx *f, double x)
 {
     double a = f->params[0];
     double n = f->params[1];
+
+    // Power of Blackman function may not be defined for all
+    // x when alpha (a) is larger than 0.16, so in that case
+    // just use Blackman function.  
+    if (a > 0.16)
+        n = 1.0;
+    
     double a0 = (1.0 - a) / 2.0, a1 = 1.0 / 2.0, a2 = a / 2.0;
     x *= M_PI;
     return pow(a0 + a1 * cos(x) + a2 * cos(2.0 * x), n);
@@ -401,7 +408,7 @@ const struct pl_filter_function pl_filter_function_gaussian = {
     .tunable   = {true},
 };
 
-//Power of Garamond window
+// Power of Garamond window
 static double garamond(const struct pl_filter_ctx *f, double x)
 {
     double n = fmax(f->params[0], 0.0);

--- a/src/include/libplacebo/filters.h
+++ b/src/include/libplacebo/filters.h
@@ -94,9 +94,14 @@ PL_API extern const struct pl_filter_function pl_filter_function_welch;
 //                and the side lobes.
 PL_API extern const struct pl_filter_function pl_filter_function_kaiser;
 
-// Blackman filter: Cosine filter named after Ralph Beebe Blackman.
+// Power of Blackman filter: Based on cosine filter named after Ralph Beebe Blackman.
 // Parameter [0]: Scale (alpha). Influences the shape. The defaults result in
 //                zeros at the third and fourth sidelobes.
+// Parameter [1]: Scale (n). Influences the shape. Controls main lobe width. Default 1.0.
+// alpha = 0.0,  n = 1.0: Hann filter.
+// alpha = 0.0,  n = 0.5: Cosine filter.
+//               n = 1.0: Blackman filter.
+//               n = 0.0: Box filter.
 PL_API extern const struct pl_filter_function pl_filter_function_blackman;
 
 // Bohman filter: 2nd order Cosine filter.

--- a/src/include/libplacebo/filters.h
+++ b/src/include/libplacebo/filters.h
@@ -97,7 +97,8 @@ PL_API extern const struct pl_filter_function pl_filter_function_kaiser;
 // Power of Blackman filter: Based on cosine filter named after Ralph Beebe Blackman.
 // Parameter [0]: Scale (alpha). Influences the shape. The defaults result in
 //                zeros at the third and fourth sidelobes.
-// Parameter [1]: Scale (n). Influences the shape. Controls main lobe width. Default 1.0.
+// Parameter [1]: Scale (n). Influences the shape. Controls main lobe width.
+//                Ignored if alpha > 0.16. Default 1.0.
 // alpha = 0.0,  n = 1.0: Hann filter.
 // alpha = 0.0,  n = 0.5: Cosine filter.
 //               n = 1.0: Blackman filter.

--- a/src/include/libplacebo/filters.h
+++ b/src/include/libplacebo/filters.h
@@ -119,6 +119,7 @@ PL_API extern const struct pl_filter_function pl_filter_function_gaussian;
 // n = 1.0,   m = 1.0:  Linear filter.
 // n = 2.0,   m = 1.0:  Welch filter.
 // n -> +inf, m <= 1.0: Box filter.
+// n = 0:               Box filter.
 //            m = 0.0:  Box filter.
 //            m = 1.0:  Garamond filter.
 PL_API extern const struct pl_filter_function pl_filter_function_garamond;

--- a/src/include/libplacebo/filters.h
+++ b/src/include/libplacebo/filters.h
@@ -107,6 +107,16 @@ PL_API extern const struct pl_filter_function pl_filter_function_bohman;
 // Parameter [0]: Scale (t), increasing makes the result blurrier.
 PL_API extern const struct pl_filter_function pl_filter_function_gaussian;
 
+// Power of Garamond function: Based on power filter named after Claude Garamond.
+// Parameter [0]: Scale(n). Influences the shape. Default 2.0.
+// Parameter [1]: Scale(m). Influences the shape. Default 1.0.
+// n = 1.0,   m = 1.0:  Linear filter.
+// n = 2.0,   m = 1.0:  Welch filter.
+// n -> +inf, m <= 1.0: Box filter.
+//            m = 0.0:  Box filter.
+//            m = 1.0:  Garamond filter.
+PL_API extern const struct pl_filter_function pl_filter_function_garamond;
+
 // Quadratic function: 2nd order approximation of the gaussian function. Also
 // sometimes called a "quadric" window.
 PL_API extern const struct pl_filter_function pl_filter_function_quadratic;


### PR DESCRIPTION
Libplacebo supports 2 free parameters for windows and in my research (https://github.com/garamond13/Finding-the-best-methods-for-image-scaling) more customizable windows have proven to be superior in quality when scaling images. Also compared to Said window and GNW, for these 2 windows we don't need to do any extra modifications to the code in order to implement them.

Reference for Power of Blackman window: https://github.com/garamond13/power-of-blackman

Reference for Power of Garamond window: https://github.com/garamond13/power-of-garamond-window