### PR TITLE
Don't export symbols from static library

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -239,7 +239,7 @@ endif
 ### Main library build process
 inc = include_directories('./include')
 lib = library('placebo', sources,
-  c_args: ['-DPL_EXPORT'],
+  c_args: get_option('default_library') == 'static' ? ['-DPL_STATIC'] : ['-DPL_EXPORT'],
   install: true,
   dependencies: build_deps + glad_dep,
   soversion: apiver,


### PR DESCRIPTION
The "both" case is likely still broken, but I see no good way to fix that with meson.

Background:
FFmpeg just started linking to libplacebo directly from ffplay.
This broke linking on Windows, since libavfilter ended up exporting the libplacebo symbols due to the forced dllexport on them.

Arguably, on Linux the visibility should likely also be set to hidden if PL_STATIC is set, since there is no point in exporting the symbols there either. But apparently the linker there is a bit smarter and figures things out.