### PR TITLE
Don't define PL_EXPORT for static build

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -239,7 +239,7 @@ endif
 ### Main library build process
 inc = include_directories('./include')
 lib = library('placebo', sources,
-  c_args: ['-DPL_EXPORT'],
+  c_args: get_option('default_library') == 'static' ? ['-DPL_STATIC'] : ['-DPL_EXPORT'],
   install: true,
   dependencies: build_deps + glad_dep,
   soversion: apiver,


### PR DESCRIPTION
This fixed FFmpeg build error when both libavfilter.dll and ffplay.exe linked to a static build libplacebo.