### PR TITLE
utils/libav: Use Vulkan HW frames context dimensions

### DIFF
--- a/src/include/libplacebo/utils/libav_internal.h
+++ b/src/include/libplacebo/utils/libav_internal.h
@@ -1137,8 +1137,8 @@ static bool pl_map_avframe_vulkan(pl_gpu gpu, struct pl_frame *out,
 
         plane->texture = pl_vulkan_wrap(gpu, pl_vulkan_wrap_params(
             .image  = vkf->img[n],
-            .width  = AV_CEIL_RSHIFT(frame->width, chroma ? desc->log2_chroma_w : 0),
-            .height = AV_CEIL_RSHIFT(frame->height, chroma ? desc->log2_chroma_h : 0),
+            .width  = AV_CEIL_RSHIFT(hwfc->width, chroma ? desc->log2_chroma_w : 0),
+            .height = AV_CEIL_RSHIFT(hwfc->height, chroma ? desc->log2_chroma_h : 0),
             .format = vk_fmt[n],
             .usage  = vkfc->usage,
         ));


### PR DESCRIPTION
Fixes mapping frames with padding (eg. 1080p ~ 1088).