### PR TITLE
gpu: add option "no_compute" to forcibly disable the use of compute shaders

### DIFF
--- a/src/d3d11/context.c
+++ b/src/d3d11/context.c
@@ -472,7 +472,7 @@ pl_d3d11 pl_d3d11_create(pl_log log, const struct pl_d3d11_params *params)
         PL_MSG(ctx, level, "Using a software adapter");
     }
 
-    d3d11->gpu = pl_gpu_create_d3d11(ctx);
+    d3d11->gpu = pl_gpu_create_d3d11(ctx, params->no_compute);
     if (!d3d11->gpu)
         goto error;
 

--- a/src/include/libplacebo/d3d11.h
+++ b/src/include/libplacebo/d3d11.h
@@ -114,6 +114,9 @@ struct pl_d3d11_params {
     int min_feature_level; // Defaults to D3D_FEATURE_LEVEL_9_1 if unset
     int max_feature_level; // Defaults to D3D_FEATURE_LEVEL_12_1 if unset
 
+    // Disable compute shaders.
+    bool no_compute;
+
     // Allow up to N in-flight frames. Similar to swapchain_depth for Vulkan and
     // OpenGL, though with DXGI this is a device-wide setting that affects all
     // swapchains (except for waitable swapchains.) See the documentation for

--- a/src/include/libplacebo/opengl.h
+++ b/src/include/libplacebo/opengl.h
@@ -75,6 +75,9 @@ struct pl_opengl_params {
     // Restrict the maximum allowed GLSL version. (Mainly for testing)
     int max_glsl_version;
 
+    // Disable compute shaders.
+    bool no_compute;
+
     // Optional. Required when importing/exporting dmabufs as textures.
     void *egl_display;
     void *egl_context;

--- a/src/include/libplacebo/vulkan.h
+++ b/src/include/libplacebo/vulkan.h
@@ -258,6 +258,7 @@ struct pl_vulkan_params {
     // for testing purposes
     int max_glsl_version;       // limit the maximum GLSL version
     uint32_t max_api_version;   // limit the maximum vulkan API version
+    bool no_compute;            // disable compute shaders
 };
 
 // Default/recommended parameters. Should generally be safe and efficient.
@@ -426,6 +427,7 @@ struct pl_vulkan_import_params {
     // for testing purposes. See `pl_vulkan_params` for a description of these.
     int max_glsl_version;
     uint32_t max_api_version;
+    bool no_compute;
 };
 
 #define pl_vulkan_import_params(...) (&(struct pl_vulkan_import_params) { __VA_ARGS__ })

--- a/src/opengl/gpu.c
+++ b/src/opengl/gpu.c
@@ -154,12 +154,16 @@ pl_gpu pl_gpu_create_gl(pl_log log, pl_opengl pl_gl, const struct pl_opengl_para
                 params->max_glsl_version, glsl->version);
     }
 
-    if (gl_test_ext(gpu, "GL_ARB_compute_shader", 43, 0) && glsl->version >= 420) {
-        glsl->compute = true;
-        get(GL_MAX_COMPUTE_SHARED_MEMORY_SIZE, &glsl->max_shmem_size);
-        get(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS, &glsl->max_group_threads);
-        for (int i = 0; i < 3; i++)
-            geti(GL_MAX_COMPUTE_WORK_GROUP_SIZE, i, &glsl->max_group_size[i]);
+    if (!params->no_compute) {
+        if (gl_test_ext(gpu, "GL_ARB_compute_shader", 43, 0) && glsl->version >= 420) {
+            glsl->compute = true;
+            get(GL_MAX_COMPUTE_SHARED_MEMORY_SIZE, &glsl->max_shmem_size);
+            get(GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS, &glsl->max_group_threads);
+            for (int i = 0; i < 3; i++)
+                geti(GL_MAX_COMPUTE_WORK_GROUP_SIZE, i, &glsl->max_group_size[i]);
+        }
+    } else {
+        PL_INFO(gpu, "Disabling compute shaders");
     }
 
     if (gl_test_ext(gpu, "GL_ARB_texture_gather", 40, 31) &&

--- a/src/vulkan/context.c
+++ b/src/vulkan/context.c
@@ -1367,7 +1367,7 @@ static void unlock_queue(pl_vulkan pl_vk, uint32_t qf, uint32_t qidx)
     vk->unlock_queue(vk->queue_ctx, qf, qidx);
 }
 
-static bool finalize_context(struct pl_vulkan_t *pl_vk, int max_glsl_version)
+static bool finalize_context(struct pl_vulkan_t *pl_vk, int max_glsl_version, bool no_compute)
 {
     struct vk_ctx *vk = PL_PRIV(pl_vk);
 
@@ -1390,6 +1390,16 @@ static bool finalize_context(struct pl_vulkan_t *pl_vk, int max_glsl_version)
         glsl->version = PL_MAX(glsl->version, 140); // required for GL_KHR_vulkan_glsl
         PL_INFO(vk, "Restricting GLSL version to %d... new version is %d",
                 max_glsl_version, glsl->version);
+    }
+    if (no_compute || (max_glsl_version && max_glsl_version < 420)) {
+        struct pl_glsl_version *glsl = (struct pl_glsl_version *) &pl_vk->gpu->glsl;
+        glsl->compute = false;
+        glsl->max_shmem_size = 0;
+        glsl->max_group_threads = 0;
+        glsl->max_group_size[0] = 0;
+        glsl->max_group_size[1] = 0;
+        glsl->max_group_size[2] = 0;
+        PL_INFO(vk, "Disabling compute shaders");
     }
 
     // Expose the resulting vulkan objects
@@ -1523,7 +1533,7 @@ pl_vulkan pl_vulkan_create(pl_log log, const struct pl_vulkan_params *params)
     if (!device_init(vk, params))
         goto error;
 
-    if (!finalize_context(pl_vk, params->max_glsl_version))
+    if (!finalize_context(pl_vk, params->max_glsl_version, params->no_compute))
         goto error;
 
     return pl_vk;
@@ -1692,7 +1702,7 @@ next_qf: ;
         goto error;
     }
 
-    if (!finalize_context(pl_vk, params->max_glsl_version))
+    if (!finalize_context(pl_vk, params->max_glsl_version, params->no_compute))
         goto error;
 
     pl_free(tmp);


### PR DESCRIPTION
See https://github.com/mpv-player/mpv/discussions/14163

Also worth noting some GPUs have better performance with fragment shaders than compute shaders. For example my Intel DG2 [Arc A750] on Linux.