### PR TITLE
opengl: prefer rgba16f over rgba32f

### DIFF
--- a/src/gpu/utils.c
+++ b/src/gpu/utils.c
@@ -175,7 +175,6 @@ pl_gpu pl_gpu_finalize(struct pl_gpu_t *gpu)
         if (!fmt->opaque) {
             pl_assert(fmt->texel_size && fmt->texel_align);
             pl_assert((fmt->texel_size % fmt->texel_align) == 0);
-            pl_assert(fmt->internal_size == fmt->texel_size || fmt->emulated);
         } else {
             pl_assert(!fmt->texel_size && !fmt->texel_align);
             pl_assert(!(fmt->caps & PL_FMT_CAP_HOST_READABLE));

--- a/src/opengl/formats.c
+++ b/src/opengl/formats.c
@@ -281,10 +281,6 @@ static void add_format(pl_gpu pgpu, const struct gl_format *gl_fmt)
         ibits += fmt->component_depth[i];
     fmt->internal_size = (ibits + 7) / 8;
 
-    // We're not the ones actually emulating these texture format - the
-    // driver is - but we might as well set the hint.
-    fmt->emulated = fmt->texel_size != fmt->internal_size;
-
     // 3-component formats are almost surely also emulated
     if (fmt->num_components == 3)
         fmt->emulated = true;


### PR DESCRIPTION
Fixes #263 

This PR does the following changes:

- Mark all non-opaque formats in OpenGL as non-emulated. Non-opaque 16f are all uploadable in OpenGL and do not involve special code path. Although the driver is emulating the transfer of them, the overall performance of 16f formats is still significantly better than 32f formats.
- When comparing formats, only compare important capabilities (i.e., the first six bits) of formats with different depth. This allows selecting a format with lower depth while sacrificing some less important capabilities. It is rare that a format with less important capabilities like `PL_FMT_CAP_TEXEL_UNIFORM` is required; if so, the caller can explicitly specify it in `pl_find_fmt()`.