### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Please open an issue if you have a use case for a BSD2-licensed libplacebo.
 
 ### Obtaining
 
-When cloning libplacebo, make sure to provide the `--recursive``` flag:
+When cloning libplacebo, make sure to provide the `--recursive` flag:
 
 ```bash
 $ git clone --recursive https://code.videolan.org/videolan/libplacebo


### PR DESCRIPTION
This fixes the MD syntax around --recursive by removing two `s.