### PR TITLE
util/libav: do not bail on MEL-only RPUs w/EL

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ project('libplacebo', ['c', 'cpp'],
     7,
     # API version
     {
+      '364': 'add pl_avdovi_metadata_supported, lift checks out of pl_map_avdovi_metadata, extend pl_avframe_params',
       '363': 'add pl_frame.pixel_aspect_ratio',
       '362': 'add PL_COLOR_TRC_SCRGB',
       '361': 'pl_swapchain_colorspace_hint can map VK_COLOR_SPACE_PASS_THROUGH_EXT',

--- a/src/include/libplacebo/utils/libav.h
+++ b/src/include/libplacebo/utils/libav.h
@@ -118,8 +118,9 @@ PL_LIBAV_API void pl_map_dovi_metadata(struct pl_dovi_metadata *out,
 // values from the `AVDOVIMetadata`.
 //
 // Note: The `pl_dovi_metadata` must be allocated externally.
-// Also, currently the metadata is only used if the `AVDOVIRpuDataHeader`
-// `disable_residual_flag` field is not zero and can be checked before allocating.
+// This function will only attempt to map the metadata if it is fully supported
+// (see `pl_map_avdovi_metadata()` and `pl_avdovi_metadata_supported()`).
+// This can be checked before allocating.
 PL_DEPRECATED_IN(v7.343) PL_LIBAV_API void pl_frame_map_avdovi_metadata(
                                                struct pl_frame *out_frame,
                                                struct pl_dovi_metadata *dovi,
@@ -131,9 +132,11 @@ PL_DEPRECATED_IN(v7.343) PL_LIBAV_API void pl_frame_map_avdovi_metadata(
 // values from the `AVDOVIMetadata`.
 //
 // Note: The `pl_dovi_metadata` must be allocated externally.
-// Currently, the metadata can only be mapped if FEL (full enhancement layer)
-// is not used and this can be checked before allocating
-// (see pl_can_map_avdovi_metadata()).
+// This function will always attempt to map the metadata, even if this mapping
+// would be incomplete due to unsupported features. The caller is advised
+// to use pl_dovi_metadata_supported() to check whether this is the case.
+// Currently, the mapping will only be complete if FEL (full enhancement layer)
+// is not used.
 PL_LIBAV_API void pl_map_avdovi_metadata(struct pl_color_space *color,
                                          struct pl_color_repr *repr,
                                          struct pl_dovi_metadata *dovi,

--- a/src/include/libplacebo/utils/libav.h
+++ b/src/include/libplacebo/utils/libav.h
@@ -131,12 +131,18 @@ PL_DEPRECATED_IN(v7.343) PL_LIBAV_API void pl_frame_map_avdovi_metadata(
 // values from the `AVDOVIMetadata`.
 //
 // Note: The `pl_dovi_metadata` must be allocated externally.
-// Also, currently the metadata is only used if the `AVDOVIRpuDataHeader`
-// `disable_residual_flag` field is not zero and can be checked before allocating.
+// Currently, the metadata can only be mapped if FEL (full enhancement layer)
+// is not used and this can be checked before allocating
+// (see pl_can_map_avdovi_metadata()).
 PL_LIBAV_API void pl_map_avdovi_metadata(struct pl_color_space *color,
                                          struct pl_color_repr *repr,
                                          struct pl_dovi_metadata *dovi,
                                          const AVDOVIMetadata *metadata);
+
+// Helper function to check if Dolby Vision metadata can be mapped.
+// Returns true if the `AVDOVIRpuDataHeader` `disable_residual_flag` field is
+// not zero or if the NLQ parameters are trivial.
+PL_LIBAV_API bool pl_avdovi_metadata_supported(const AVDOVIMetadata *metadata);
 #endif
 
 // Helper function to test if a pixfmt would be supported by the GPU.

--- a/src/include/libplacebo/utils/libav.h
+++ b/src/include/libplacebo/utils/libav.h
@@ -184,6 +184,10 @@ struct pl_avframe_params {
     // Also map Dolby Vision metadata (if supported). Note that this also
     // overrides the colorimetry metadata (forces BT.2020+PQ).
     bool map_dovi;
+
+    // Ignore the checks and always map Dolby Vision metadata (even if this
+    // mapping will be incomplete). Does not imply ->map_dovi.
+    bool map_dovi_force;
 };
 
 #define PL_AVFRAME_DEFAULTS \

--- a/src/include/libplacebo/utils/libav_internal.h
+++ b/src/include/libplacebo/utils/libav_internal.h
@@ -1335,7 +1335,7 @@ PL_LIBAV_API bool pl_map_avframe_ex(pl_gpu gpu, struct pl_frame *out,
         if (sd) {
             const AVDOVIMetadata *metadata = (AVDOVIMetadata *) sd->data;
             // Only automatically map DoVi RPUs that don't require a (full) EL
-            if (pl_avdovi_metadata_supported(metadata))
+            if (params->map_dovi_force || pl_avdovi_metadata_supported(metadata))
                 pl_map_avdovi_metadata(&out->color, &out->repr, &priv->dovi, metadata);
         }
 

--- a/src/include/libplacebo/utils/libav_internal.h
+++ b/src/include/libplacebo/utils/libav_internal.h
@@ -996,26 +996,24 @@ PL_LIBAV_API void pl_map_avdovi_metadata(struct pl_color_space *color,
     if (!color || !repr || !dovi)
         return;
 
-    if (pl_avdovi_metadata_supported(metadata)) {
-        dovi_color = av_dovi_get_color(metadata);
-        pl_map_dovi_metadata(dovi, metadata);
+    dovi_color = av_dovi_get_color(metadata);
+    pl_map_dovi_metadata(dovi, metadata);
 
-        repr->dovi = dovi;
-        repr->sys = PL_COLOR_SYSTEM_DOLBYVISION;
-        color->primaries = PL_COLOR_PRIM_BT_2020;
-        color->transfer = PL_COLOR_TRC_PQ;
-        color->hdr.min_luma =
-            pl_hdr_rescale(PL_HDR_PQ, PL_HDR_NITS, dovi_color->source_min_pq / 4095.0f);
-        color->hdr.max_luma =
-            pl_hdr_rescale(PL_HDR_PQ, PL_HDR_NITS, dovi_color->source_max_pq / 4095.0f);
+    repr->dovi = dovi;
+    repr->sys = PL_COLOR_SYSTEM_DOLBYVISION;
+    color->primaries = PL_COLOR_PRIM_BT_2020;
+    color->transfer = PL_COLOR_TRC_PQ;
+    color->hdr.min_luma =
+        pl_hdr_rescale(PL_HDR_PQ, PL_HDR_NITS, dovi_color->source_min_pq / 4095.0f);
+    color->hdr.max_luma =
+        pl_hdr_rescale(PL_HDR_PQ, PL_HDR_NITS, dovi_color->source_max_pq / 4095.0f);
 
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(59, 12, 100)
-        if ((dovi_ext = av_dovi_find_level(metadata, 1))) {
-            color->hdr.max_pq_y = dovi_ext->l1.max_pq / 4095.0f;
-            color->hdr.avg_pq_y = dovi_ext->l1.avg_pq / 4095.0f;
-        }
-#endif
+    if ((dovi_ext = av_dovi_find_level(metadata, 1))) {
+        color->hdr.max_pq_y = dovi_ext->l1.max_pq / 4095.0f;
+        color->hdr.avg_pq_y = dovi_ext->l1.avg_pq / 4095.0f;
     }
+#endif
 }
 
 PL_LIBAV_API void pl_frame_map_avdovi_metadata(struct pl_frame *out_frame,
@@ -1024,7 +1022,8 @@ PL_LIBAV_API void pl_frame_map_avdovi_metadata(struct pl_frame *out_frame,
 {
     if (!out_frame)
         return;
-    pl_map_avdovi_metadata(&out_frame->color, &out_frame->repr, dovi, metadata);
+    if (pl_avdovi_metadata_supported(metadata))
+        pl_map_avdovi_metadata(&out_frame->color, &out_frame->repr, dovi, metadata);
 }
 #endif // PL_HAVE_LAV_DOLBY_VISION
 

--- a/src/include/libplacebo/utils/libav_internal.h
+++ b/src/include/libplacebo/utils/libav_internal.h
@@ -946,12 +946,49 @@ PL_LIBAV_API void pl_map_dovi_metadata(struct pl_dovi_metadata *out,
     }
 }
 
+static bool pl_avdovi_nlq_is_trivial(const AVDOVIRpuDataHeader *header,
+                                     const AVDOVINLQParams *nlq)
+{
+    return
+        nlq->nlq_offset == 0
+        && nlq->vdr_in_max == (1ULL << header->coef_log2_denom)
+        && nlq->linear_deadzone_slope == 0
+        && nlq->linear_deadzone_threshold == 0
+    ;
+}
+
+static bool pl_avdovi_mapping_nlq_is_trivial(const AVDOVIRpuDataHeader *header,
+                                             const AVDOVIDataMapping *mapping)
+{
+    return
+        mapping->nlq_method_idc == AV_DOVI_NLQ_LINEAR_DZ
+        && pl_avdovi_nlq_is_trivial(header, &mapping->nlq[0])
+        && pl_avdovi_nlq_is_trivial(header, &mapping->nlq[1])
+        && pl_avdovi_nlq_is_trivial(header, &mapping->nlq[2])
+    ;
+}
+
+PL_LIBAV_API bool pl_avdovi_metadata_supported(const AVDOVIMetadata *metadata)
+{
+    const AVDOVIRpuDataHeader *header;
+    const AVDOVIDataMapping *mapping;
+
+    header = av_dovi_get_header(metadata);
+    if (header->disable_residual_flag)
+        return true;
+
+    mapping = av_dovi_get_mapping(metadata);
+    if (pl_avdovi_mapping_nlq_is_trivial(header, mapping))
+        return true;
+
+    return false;
+}
+
 PL_LIBAV_API void pl_map_avdovi_metadata(struct pl_color_space *color,
                                          struct pl_color_repr *repr,
                                          struct pl_dovi_metadata *dovi,
                                          const AVDOVIMetadata *metadata)
 {
-    const AVDOVIRpuDataHeader *header;
     const AVDOVIColorMetadata *dovi_color;
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(59, 12, 100)
     const AVDOVIDmData *dovi_ext;
@@ -959,9 +996,8 @@ PL_LIBAV_API void pl_map_avdovi_metadata(struct pl_color_space *color,
     if (!color || !repr || !dovi)
         return;
 
-    header = av_dovi_get_header(metadata);
-    dovi_color = av_dovi_get_color(metadata);
-    if (header->disable_residual_flag) {
+    if (pl_avdovi_metadata_supported(metadata)) {
+        dovi_color = av_dovi_get_color(metadata);
         pl_map_dovi_metadata(dovi, metadata);
 
         repr->dovi = dovi;
@@ -1299,9 +1335,8 @@ PL_LIBAV_API bool pl_map_avframe_ex(pl_gpu gpu, struct pl_frame *out,
         AVFrameSideData *sd = av_frame_get_side_data(frame, AV_FRAME_DATA_DOVI_METADATA);
         if (sd) {
             const AVDOVIMetadata *metadata = (AVDOVIMetadata *) sd->data;
-            const AVDOVIRpuDataHeader *header = av_dovi_get_header(metadata);
-            // Only automatically map DoVi RPUs that don't require an EL
-            if (header->disable_residual_flag)
+            // Only automatically map DoVi RPUs that don't require a (full) EL
+            if (pl_avdovi_metadata_supported(metadata))
                 pl_map_avdovi_metadata(&out->color, &out->repr, &priv->dovi, metadata);
         }
 


### PR DESCRIPTION
We can still map DV metadata that indicates enhancement layer usage (!disable_residual_flag, Profile 7 and 4) for MEL-only bitstreams, which is indicated by trivial NLQ parameters.