### PR TITLE
MingW64 compatible build with MSVC by changing convert.cc to convert.c

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -15,140 +15,82 @@
  * License along with libplacebo. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <limits>
 #include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
 #include "pl_string.h"
 
-// Function prototypes
-static int ccStrPrintDouble(char *str, int bufsize, int decimals, double value);
-static bool fast_float_from_chars(const char *str, double *n); // Declaration for fast_float
 
-// Function to print a double as a string
-static int ccStrPrintDouble(char *str, int bufsize, int decimals, double value) {
-    int size = 0;
-    int offset = 0;
-    uint32_t u32;
-    uint64_t u64;
-
-    if (value < 0.0) {
-        size = 1;
-        *str++ = '-';
-        bufsize--;
-        value = -value;
-    }
-
-    if (value < 4294967296.0) {
-        u32 = (uint32_t)value;
-        offset = pl_str_print_uint(str, bufsize, u32);
-        if (!offset) goto error;
-        size += offset;
-        bufsize -= size;
-        value -= (double)u32;
-    } else if (value < 18446744073709551616.0) {
-        u64 = (uint64_t)value;
-        offset = pl_str_print_uint64(str, bufsize, u64);
-        if (!offset) goto error;
-        size += offset;
-        bufsize -= size;
-        value -= (double)u64;
-    } else {
-        goto error;
-    }
-
-    if (decimals > bufsize - 2) decimals = bufsize - 2;
-    if (decimals <= 0) return size;
-
-    double muldec = 10.0;
-    int32_t accumsub = 0;
-    str += offset;
-
-    for (int index = 0; index < decimals; index++) {
-        if (value * muldec - accumsub <= std::numeric_limits<double>::epsilon()) break;
-        if (index == 0) {
-            size += 1;
-            *str++ = '.';
-        }
-        int32_t frac = (int32_t)(value * muldec) - accumsub;
-        frac = (frac < 0) ? 0 : (frac > 9) ? 9 : frac; // Clamp frac between 0 and 9
-        str[index] = '0' + (char)frac;
-        accumsub += frac;
-        accumsub = (accumsub << 3) + (accumsub << 1);
-        if (muldec < 10000000) {
-            muldec *= 10.0;
-        } else {
-            value *= 10000000.0;
-            value -= (int32_t)value;
-            muldec = 10.0;
-            accumsub = 0;
-        }
-    }
-    if (str[index - 1] < '9' && (int32_t)(value * muldec) - accumsub >= 5) {
-        str[index - 1]++;
-    }
-    str[index] = '\0'; // Null-terminate the string
-    size += index;
-    return size;
-
-error:
-    if (bufsize < 4) *str = '\0';
-    else {
-        str[0] = 'E';
-        str[1] = 'R';
-        str[2] = 'R';
-        str[3] = '\0';
-    }
-    return 0;
+int pl_str_print_hex(char* buf, size_t len, unsigned short value)
+{
+    return snprintf(buf, len, "%x", value);
 }
 
-// Function to parse from string to double using fast_float
-static bool from_chars(pl_str str, double *n) {
-#if __has_include(<fast_float/fast_float.h>)
-    return fast_float_from_chars((const char *)str.buf, n); // Use fast_float
-#else
-    // Handle error when fast_float is not available
-    return false;
-#endif
+int pl_str_print_int(char* buf, size_t len, int value)
+{
+    return snprintf(buf, len, "%d", value);
 }
 
-// Function to print values to a string
-#define CHAR_CONVERT(name, type)                         \
-    int pl_str_print_##name(char *buf, size_t len, type n) { \
-        if (sizeof(type) == sizeof(double)) {           \
-            return ccStrPrintDouble(buf, len, 10, n);   \
-        }                                               \
-        return 0;                                       \
-    }                                                   \
-    bool pl_str_parse_##name(pl_str str, type *n) {     \
-        return from_chars(str, n);                      \
-    }
+int pl_str_print_uint(char* buf, size_t len, unsigned int value)
+{
+    return snprintf(buf, len, "%u", value);
+}
 
-CHAR_CONVERT(hex, unsigned short)
-CHAR_CONVERT(int, int)
-CHAR_CONVERT(uint, unsigned int)
-CHAR_CONVERT(int64, int64_t)
-CHAR_CONVERT(uint64, uint64_t)
-CHAR_CONVERT(float, float)
-CHAR_CONVERT(double, double)
+int pl_str_print_int64(char* buf, size_t len, int64_t value)
+{
+    return snprintf(buf, len, "%" PRId64, value);
+}
 
-/* *****************************************************************************
- *
- * Copyright (c) 2007-2016 Alexis Naveros.
- * Modified for use with libplacebo by Niklas Haas
- * Changes include:
- *  - Removed a CC_MIN macro dependency by equivalent logic
- *  - Removed CC_ALWAYSINLINE
- *  - Fixed (!seq) check to (!seqlength)
- *  - Added support for scientific notation (e.g. 1.0e10) in ccSeqParseDouble
- *
- * Permission is granted to anyone to use this software for any purpose,
- * including commercial applications, and to alter it and redistribute it
- * freely, subject to the following restrictions:
- *
- * 1. The origin of this software must not be misrepresented; you must not
- * claim that you wrote the original software. If you use this software
- * in a product, an acknowledgment in the product documentation would be appreciated but is not required.
- * 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
- * 3. This notice may not be removed or altered from any source distribution.
- *
- * ----------------------------------------------------------------------------- 
- */
+int pl_str_print_uint64(char* buf, size_t len, uint64_t value)
+{
+    return snprintf(buf, len, "%" PRIu64, value);
+}
+
+int pl_str_print_float(char* buf, size_t len, float value)
+{
+    return snprintf(buf, len, "%g", value);
+}
+
+int pl_str_print_double(char* buf, size_t len, double value)
+{
+    return snprintf(buf, len, "%g", value);
+}
+
+
+
+
+bool pl_str_parse_hex(pl_str str, short unsigned int* value)
+{
+    return pl_str_sscanf(str, "0x%x", value);
+}
+
+bool pl_str_parse_int(pl_str str, int* value)
+{
+    return pl_str_sscanf(str, "%d", value);
+}
+
+bool pl_str_parse_uint(pl_str str, unsigned int* value)
+{
+    return pl_str_sscanf(str, "%u", value);
+}
+
+bool pl_str_parse_int64(pl_str str, int64_t* value)
+{
+    return pl_str_sscanf(str, "%" PRId64, value);
+}
+
+bool pl_str_parse_uint64(pl_str str, uint64_t* value)
+{
+    return pl_str_sscanf(str, "%" PRIu64, value);
+}
+
+bool pl_str_parse_float(pl_str str, float* value)
+{
+    return pl_str_sscanf(str, "%g", value);
+}
+
+bool pl_str_parse_double(pl_str str, double* value)
+{
+    return pl_str_sscanf(str, "%g", value);
+}
+

--- a/src/convert.c
+++ b/src/convert.c
@@ -1,0 +1,154 @@
+/*
+ * This file is part of libplacebo.
+ *
+ * libplacebo is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * libplacebo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with libplacebo. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <limits>
+#include <string.h>
+#include "pl_string.h"
+
+// Function prototypes
+static int ccStrPrintDouble(char *str, int bufsize, int decimals, double value);
+static bool fast_float_from_chars(const char *str, double *n); // Declaration for fast_float
+
+// Function to print a double as a string
+static int ccStrPrintDouble(char *str, int bufsize, int decimals, double value) {
+    int size = 0;
+    int offset = 0;
+    uint32_t u32;
+    uint64_t u64;
+
+    if (value < 0.0) {
+        size = 1;
+        *str++ = '-';
+        bufsize--;
+        value = -value;
+    }
+
+    if (value < 4294967296.0) {
+        u32 = (uint32_t)value;
+        offset = pl_str_print_uint(str, bufsize, u32);
+        if (!offset) goto error;
+        size += offset;
+        bufsize -= size;
+        value -= (double)u32;
+    } else if (value < 18446744073709551616.0) {
+        u64 = (uint64_t)value;
+        offset = pl_str_print_uint64(str, bufsize, u64);
+        if (!offset) goto error;
+        size += offset;
+        bufsize -= size;
+        value -= (double)u64;
+    } else {
+        goto error;
+    }
+
+    if (decimals > bufsize - 2) decimals = bufsize - 2;
+    if (decimals <= 0) return size;
+
+    double muldec = 10.0;
+    int32_t accumsub = 0;
+    str += offset;
+
+    for (int index = 0; index < decimals; index++) {
+        if (value * muldec - accumsub <= std::numeric_limits<double>::epsilon()) break;
+        if (index == 0) {
+            size += 1;
+            *str++ = '.';
+        }
+        int32_t frac = (int32_t)(value * muldec) - accumsub;
+        frac = (frac < 0) ? 0 : (frac > 9) ? 9 : frac; // Clamp frac between 0 and 9
+        str[index] = '0' + (char)frac;
+        accumsub += frac;
+        accumsub = (accumsub << 3) + (accumsub << 1);
+        if (muldec < 10000000) {
+            muldec *= 10.0;
+        } else {
+            value *= 10000000.0;
+            value -= (int32_t)value;
+            muldec = 10.0;
+            accumsub = 0;
+        }
+    }
+    if (str[index - 1] < '9' && (int32_t)(value * muldec) - accumsub >= 5) {
+        str[index - 1]++;
+    }
+    str[index] = '\0'; // Null-terminate the string
+    size += index;
+    return size;
+
+error:
+    if (bufsize < 4) *str = '\0';
+    else {
+        str[0] = 'E';
+        str[1] = 'R';
+        str[2] = 'R';
+        str[3] = '\0';
+    }
+    return 0;
+}
+
+// Function to parse from string to double using fast_float
+static bool from_chars(pl_str str, double *n) {
+#if __has_include(<fast_float/fast_float.h>)
+    return fast_float_from_chars((const char *)str.buf, n); // Use fast_float
+#else
+    // Handle error when fast_float is not available
+    return false;
+#endif
+}
+
+// Function to print values to a string
+#define CHAR_CONVERT(name, type)                         \
+    int pl_str_print_##name(char *buf, size_t len, type n) { \
+        if (sizeof(type) == sizeof(double)) {           \
+            return ccStrPrintDouble(buf, len, 10, n);   \
+        }                                               \
+        return 0;                                       \
+    }                                                   \
+    bool pl_str_parse_##name(pl_str str, type *n) {     \
+        return from_chars(str, n);                      \
+    }
+
+CHAR_CONVERT(hex, unsigned short)
+CHAR_CONVERT(int, int)
+CHAR_CONVERT(uint, unsigned int)
+CHAR_CONVERT(int64, int64_t)
+CHAR_CONVERT(uint64, uint64_t)
+CHAR_CONVERT(float, float)
+CHAR_CONVERT(double, double)
+
+/* *****************************************************************************
+ *
+ * Copyright (c) 2007-2016 Alexis Naveros.
+ * Modified for use with libplacebo by Niklas Haas
+ * Changes include:
+ *  - Removed a CC_MIN macro dependency by equivalent logic
+ *  - Removed CC_ALWAYSINLINE
+ *  - Fixed (!seq) check to (!seqlength)
+ *  - Added support for scientific notation (e.g. 1.0e10) in ccSeqParseDouble
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * ----------------------------------------------------------------------------- 
+ */

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,18 +37,18 @@ if host_machine.system() == 'windows' and mingw32 != '' and host_machine.cpu() i
   add_project_arguments(['-D__CRT__NO_INLINE'], language: ['c', 'cpp'])
 endif
 
-# Work around missing atomics on some (obscure) platforms
-atomic_test = '''
-#include <stdatomic.h>
-#include <stdint.h>
-int main(void) {
-  _Atomic uint32_t x32;
-  atomic_init(&x32, 0);
-}'''
+# # Work around missing atomics on some (obscure) platforms
+# atomic_test = '''
+# #include <stdatomic.h>
+# #include <stdint.h>
+# int main(void) {
+#   _Atomic uint32_t x32;
+#   atomic_init(&x32, 0);
+# }'''
 
-if not cc.links(atomic_test)
-  build_deps += cc.find_library('atomic')
-endif
+# if not cc.links(atomic_test)
+#   build_deps += cc.find_library('atomic')
+# endif
 
 
 ### Common source files
@@ -92,7 +92,8 @@ sources = [
   'cache.c',
   'colorspace.c',
   'common.c',
-  'convert.cc',
+  'convert.c',
+  # 'convert.cc',
   'dither.c',
   'dispatch.c',
   'dummy.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,18 +37,18 @@ if host_machine.system() == 'windows' and mingw32 != '' and host_machine.cpu() i
   add_project_arguments(['-D__CRT__NO_INLINE'], language: ['c', 'cpp'])
 endif
 
-# # Work around missing atomics on some (obscure) platforms
-# atomic_test = '''
-# #include <stdatomic.h>
-# #include <stdint.h>
-# int main(void) {
-#   _Atomic uint32_t x32;
-#   atomic_init(&x32, 0);
-# }'''
+# Work around missing atomics on some (obscure) platforms
+atomic_test = '''
+#include <stdatomic.h>
+#include <stdint.h>
+int main(void) {
+  _Atomic uint32_t x32;
+  atomic_init(&x32, 0);
+}'''
 
-# if not cc.links(atomic_test)
-#   build_deps += cc.find_library('atomic')
-# endif
+if not cc.links(atomic_test)
+  build_deps += cc.find_library('atomic')
+endif
 
 
 ### Common source files

--- a/tools/glsl_preproc/macros.py
+++ b/tools/glsl_preproc/macros.py
@@ -84,7 +84,7 @@ class Macro(object):
 
             if macro:
                 if leading_spaces:
-                    line = re.sub(f'^\s{{1,{leading_spaces}}}', '', line)
+                    line = re.sub(f'^\\s{{1,{leading_spaces}}}', '', line)
                 if more_lines := line.endswith('\\'):
                     line = line[:-1]
                 if statement := Statement.parse(line, strip=strip, linenr=linenr):


### PR DESCRIPTION
MingW64 compilation on Windows would work as a DLL, but it would not allow linking libplacebo with MSVC due to the use of the libstdc++ in at least one file: convert.cc.

This PR adds a C convert.c file with C functions instead of C++ ones, which can be linked safely between compilers.

It is not as efficient as the C++ implementation but it allows Windows interoperatibility.