### PR TITLE
demos/settings: move parse_args out of HAVE_NUKLEAR ifdef

### DIFF
--- a/demos/settings.c
+++ b/demos/settings.c
@@ -14,9 +14,6 @@
 #define PL_BASENAME basename
 #endif
 
-#ifdef HAVE_NUKLEAR
-#include "ui.h"
-
 bool parse_args(struct plplay_args *args, int argc, char *argv[])
 {
     static struct option long_options[] = {
@@ -88,6 +85,9 @@ error:
     fprintf(stderr, "  -w, --window    Specify the windowing API\n");
     return false;
 }
+
+#ifdef HAVE_NUKLEAR
+#include "ui.h"
 
 static void add_hook(struct plplay *p, const struct pl_hook *hook, const char *path)
 {


### PR DESCRIPTION
In case demos are compiled, but the nuklear headers are not available, compilation fails, because the implementation of `parse_args` function is protected by the HAVE_NUKLEAR preprocessor macro.

In this case the linking fails with the following error:

```
| /yocto/sandbox/build/tmp/work/cortexa53-poky-linux/libplacebo/7.349.0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/14.2.0/ld: demos/plplay.p/plplay.c.o: in function `main':
| /usr/src/debug/libplacebo/7.349.0/demos/plplay.c:669:(.text.startup+0x90): undefined reference to `parse_args'
| collect2: error: ld returned 1 exit status
```

To solve this, this PR moves the parse_args implementation outside of the ifdef guard.