### PR TITLE
Pull Request for the Black Level detection Feature.

### DIFF
--- a/src/colorspace.c
+++ b/src/colorspace.c
@@ -793,6 +793,7 @@ void pl_color_space_nominal_luma_ex(const struct pl_nominal_luma_params *params)
     {
         max_luma = pl_hdr_rescale(PL_HDR_PQ, scaling, csp->hdr.max_pq_y);
         avg_luma = pl_hdr_rescale(PL_HDR_PQ, scaling, csp->hdr.avg_pq_y);
+        min_luma = pl_hdr_rescale(PL_HDR_PQ, scaling, csp->hdr.min_pq_y);
     }
 
     // Clamp to sane value range
@@ -805,7 +806,7 @@ void pl_color_space_nominal_luma_ex(const struct pl_nominal_luma_params *params)
 
     // PQ is always scaled down to absolute black, ignoring HDR metadata
     if (csp->transfer == PL_COLOR_TRC_PQ)
-        min_luma = hdr_min;
+        min_luma = pl_hdr_rescale(PL_HDR_PQ, scaling, csp->hdr.min_pq_y);
 
     // Baseline/fallback metadata, inferred entirely from the colorspace
     // description and built-in default assumptions

--- a/src/include/libplacebo/colorspace.h
+++ b/src/include/libplacebo/colorspace.h
@@ -412,6 +412,7 @@ struct pl_hdr_metadata {
     // --- PL_HDR_METADATA_CIE_Y
     float max_pq_y;                 // maximum PQ luminance (in PQ, 0-1)
     float avg_pq_y;                 // averaged PQ luminance (in PQ, 0-1)
+    float min_pq_y;
 };
 
 PL_API extern const struct pl_hdr_metadata pl_hdr_metadata_empty; // equal to {0}

--- a/src/include/libplacebo/shaders/colorspace.h
+++ b/src/include/libplacebo/shaders/colorspace.h
@@ -119,6 +119,7 @@ struct pl_peak_detect_params {
     //
     // Setting either one of these to 0.0 disables this logic.
     float scene_threshold_low;
+    float scene_threshold_avg;
     float scene_threshold_high;
 
     // Which percentile of the input image brightness histogram to consider as
@@ -131,7 +132,8 @@ struct pl_peak_detect_params {
     // A recommended value is 99.995%, which is very conservative and should
     // cause no major issues in typical content.
     float percentile;
-
+    float black_percentile;
+    float black_maxadvance;
     // Black cutoff strength. To prevent unnatural pixel shimmer and excessive
     // darkness in mostly black scenes, as well as avoid black bars from
     // affecting the content, (smoothly) cut off any value below this (PQ%)
@@ -154,11 +156,15 @@ struct pl_peak_detect_params {
     .scene_threshold_low    = 1.0f,     \
     .scene_threshold_high   = 3.0f,     \
     .percentile             = 100.0f,   \
+    .black_percentile       = 1.0f,     \
+    .black_maxadvance       = 7.0f,     \
     .black_cutoff           = 1.0f,
 
 #define PL_PEAK_DETECT_HQ_DEFAULTS      \
     PL_PEAK_DETECT_DEFAULTS             \
-    .percentile             = 99.995f,
+    .percentile             = 99.995f,  \
+    .black_percentile       = 0.5f,     \
+    .black_maxadvance       = 4.9f,
 
 #define pl_peak_detect_params(...) (&(struct pl_peak_detect_params) { PL_PEAK_DETECT_DEFAULTS __VA_ARGS__ })
 PL_API extern const struct pl_peak_detect_params pl_peak_detect_default_params;

--- a/src/options.c
+++ b/src/options.c
@@ -958,9 +958,12 @@ const struct pl_opt_t pl_option_list[] = {
                {"high_quality", &pl_peak_detect_high_quality_params})),
     OPT_FLOAT("peak_smoothing_period", "Peak detection smoothing coefficient", peak_detect_params.smoothing_period, .max = 1000.0),
     OPT_FLOAT("scene_threshold_low", "Scene change threshold low", peak_detect_params.scene_threshold_low, .max = 100.0),
+    OPT_FLOAT("scene_threshold_avg", "Scene change threshold avg", peak_detect_params.scene_threshold_avg, .max = 100.0),
     OPT_FLOAT("scene_threshold_high", "Scene change threshold high", peak_detect_params.scene_threshold_high, .max = 100.0),
     OPT_FLOAT("minimum_peak", "Minimum detected peak", peak_detect_params.minimum_peak, .max = 100.0, .deprecated = true),
-    OPT_FLOAT("peak_percentile", "Peak detection percentile", peak_detect_params.percentile, .max = 100.0),
+    OPT_FLOAT("peak_percentile", "Black detection percentile", peak_detect_params.percentile, .max = 100.0),
+    OPT_FLOAT("black_percentile", "Black detection percentile", peak_detect_params.black_percentile, .max = 100.0),
+    OPT_FLOAT("black_maxadvance", "Black detection maximum Advance in percent PQ", peak_detect_params.black_maxadvance, .max = 100.0),
     OPT_FLOAT("black_cutoff", "Peak detection black cutoff", peak_detect_params.black_cutoff, .max = 100.0),
     OPT_BOOL("allow_delayed_peak", "Allow delayed peak detection", peak_detect_params.allow_delayed),
 

--- a/src/shaders/colorspace.c
+++ b/src/shaders/colorspace.c
@@ -915,21 +915,26 @@ static bool peak_detect_params_eq(const struct pl_peak_detect_params *a,
 enum {
     // Split the peak buffer into several independent slices to reduce pressure
     // on global atomics
-    SLICES = 12,
+    // Seemed to be unnecessary. Works with only 2 slices. Dont know how to deactivate this (slices=1) due to compilation errors
+    // Makes peak-detection functions way more easy.
+    SLICES = 2,
 
     // How many bits to use for storing PQ data. Be careful when setting this
     // too high, as it may overflow `unsigned int` on large video sources.
     //
     // The value chosen is enough to guarantee no overflow for an 8K x 4K frame
     // consisting entirely of 100% 10k nits PQ values, with 16x16 workgroups.
-    PQ_BITS     = 14,
+    PQ_BITS     = 12,
     PQ_MAX      = (1 << PQ_BITS) - 1,
 
     // How many bits to use for the histogram. We bias the histogram down
     // by half the PQ range (~90 nits), effectively clumping the SDR part
     // of the image into a single histogram bin.
-    HIST_BITS   = 7,
-    HIST_BIAS   = 1 << (HIST_BITS - 1),
+    // 10 Bits of resolution (true HDR resolution) is needed, as with 7 bits and 12 slices (as it was before) the peak detect algorithm was just a statistical workaround.
+    // This workaround does not work on the new measure_black algorithm, as the values will jump around, and they will be very inaccuarte.
+    HIST_BITS   = 12,
+    // Before, histogram was splitted into <100nits / >100nits. Everything <100nits wasnt practically useable.
+    HIST_BIAS   = 0,
     HIST_BINS   = (1 << HIST_BITS) - HIST_BIAS,
 
     // Convert from histogram bin to (starting) PQ value
@@ -990,6 +995,7 @@ struct sh_color_map_obj {
         pl_buf readback;                        // readback buffer (fallback)
         float avg_pq;                           // current (smoothed) values
         float max_pq;
+        float min_pq;
     } peak;
 };
 
@@ -1025,53 +1031,58 @@ static inline float iir_coeff(float rate)
 
 static float measure_peak(const struct peak_buf_data *data, float percentile)
 {
-    unsigned frame_max_pq = data->frame_max_pq[0];
-    for (int k = 1; k < SLICES; k++)
-        frame_max_pq = PL_MAX(frame_max_pq, data->frame_max_pq[k]);
+    unsigned frame_max_pq = data->frame_max_pq[0]+data->frame_max_pq[1];
     const float frame_max = (float) frame_max_pq / PQ_MAX;
     if (percentile <= 0 || percentile >= 100)
         return frame_max;
+
     unsigned total_pixels = 0;
-    for (int k = 0; k < SLICES; k++) {
-        for (int i = 0; i < HIST_BINS; i++)
-            total_pixels += data->frame_hist[k][i];
-    }
+    for (int i = 0; i < HIST_BINS; i++)
+        total_pixels += data->frame_hist[0][i] + data->frame_hist[1][i];
     if (!total_pixels) // no histogram data available?
         return frame_max;
-
     const unsigned target_pixel = ceilf(percentile / 100.0f * total_pixels);
     if (target_pixel >= total_pixels)
         return frame_max;
 
+    //This function got way more easy, as only 2 slices exist due to changes in histogram.
+    //TODO: Remove slices completely. Just count pixels per bin. I am a noob, it lead to compile errors in my case if i set SLICES=1
     unsigned sum = 0;
-    for (int i = 0; i < HIST_BINS; i++) {
-        unsigned next = sum;
-        for (int k = 0; k < SLICES; k++)
-            next += data->frame_hist[k][i];
-        if (next < target_pixel) {
-            sum = next;
-            continue;
-        }
-
-        // Upper and lower frequency boundaries of the matching histogram bin
-        const unsigned count_low  = sum;      // last pixel of previous bin
-        const unsigned count_high = next + 1; // first pixel of next bin
-        pl_assert(count_low < target_pixel && target_pixel < count_high);
-
-        // PQ luminance associated with count_low/high respectively
-        const float pq_low  = (float) HIST_PQ(i)     / PQ_MAX;
-        float pq_high       = (float) HIST_PQ(i + 1) / PQ_MAX;
-        if (count_high > total_pixels) // special case for last histogram bin
-            pq_high = frame_max;
-
-        // Position of `target_pixel` inside this bin, assumes pixels are
-        // equidistributed inside a histogram bin
-        const float ratio = (float) (target_pixel - count_low) /
-                                    (count_high - count_low);
-        return PL_MIX(pq_low, pq_high, ratio);
+    float return_value = 0;
+    for (int i = 1; i < HIST_BINS; i++) {
+        sum += data->frame_hist[0][i]+data->frame_hist[1][i];
+        if (sum > target_pixel){
+            return_value = (float)HIST_PQ(i) / PQ_MAX;
+            break;}
     }
+    return return_value;
+}
 
-    pl_unreachable();
+static float measure_black(const struct peak_buf_data *data, float percentile, float maxadvance)
+{
+    if (percentile <= 0 || percentile >= 100)
+        return PL_COLOR_HDR_BLACK;
+
+    unsigned total_pixels = 0;
+    for (int i = 0; i < HIST_BINS; i++)
+        total_pixels += data->frame_hist[0][i] + data->frame_hist[1][i];
+    if (!total_pixels) // no histogram data available?
+        return PL_COLOR_HDR_BLACK;
+    const unsigned target_pixel = ceilf(percentile / 100.0f * total_pixels);
+    if (target_pixel >= total_pixels)
+        return PL_COLOR_HDR_BLACK;
+
+    unsigned sum = 0;
+    float return_value = 0;
+    for (int i = 1; i < HIST_BINS; i++) {
+        sum += data->frame_hist[0][i]+data->frame_hist[1][i];
+        if (sum > target_pixel){
+            return_value = (float)HIST_PQ(i) / PQ_MAX;
+            break;}
+    }
+    if (return_value > (maxadvance/100.0f))
+        return_value = maxadvance/100.0f;
+    return return_value;
 }
 
 // if `force` is true, ensures the buffer is read, even if `allow_delayed`
@@ -1118,44 +1129,50 @@ static void update_peak_buf(pl_gpu gpu, struct sh_color_map_obj *obj, bool force
         frame_wg_count  += data.frame_wg_count[k];
         frame_wg_active += data.frame_wg_active[k];
     }
-    float avg_pq, max_pq;
-    if (frame_wg_active) {
-        avg_pq = (float) frame_sum_pq / (frame_wg_active * PQ_MAX);
-        max_pq = measure_peak(&data, params->percentile);
-    } else {
-        // Solid black frame
-        avg_pq = max_pq = PL_COLOR_HDR_BLACK;
-    }
+    float avg_pq, max_pq, min_pq;
+    avg_pq = (float) frame_sum_pq / (frame_wg_active * PQ_MAX);
+    max_pq = measure_peak(&data, params->percentile);
+    min_pq = measure_black(&data, params->black_percentile, params->black_maxadvance);
 
-    if (!obj->peak.avg_pq) {
-        // Set the initial value accordingly if it contains no data
+    // Set the initial value accordingly if it contains no data
+    if (!obj->peak.min_pq)
+        obj->peak.min_pq =min_pq;
+    if (!obj->peak.avg_pq)
         obj->peak.avg_pq = avg_pq;
+    if (!obj->peak.max_pq)
         obj->peak.max_pq = max_pq;
-    } else {
-        // Ignore small deviations from existing peak (rounding error)
-        static const float epsilon = 1.0f / PQ_MAX;
-        if (fabsf(avg_pq - obj->peak.avg_pq) < epsilon)
-            avg_pq = obj->peak.avg_pq;
-        if (fabsf(max_pq - obj->peak.max_pq) < epsilon)
-            max_pq = obj->peak.max_pq;
-    }
 
     // Use an IIR low-pass filter to smooth out the detected values
-    const float coeff = iir_coeff(params->smoothing_period);
-    obj->peak.avg_pq += coeff * (avg_pq - obj->peak.avg_pq);
-    obj->peak.max_pq += coeff * (max_pq - obj->peak.max_pq);
+    //const float coeff = iir_coeff(params->smoothing_period);
+    //obj->peak.avg_pq += coeff * (avg_pq - obj->peak.avg_pq);
+    //obj->peak.max_pq += coeff * (max_pq - obj->peak.max_pq);
 
     // Scene change hysteresis
-    if (params->scene_threshold_low > 0 && params->scene_threshold_high > 0) {
-        const float log10_pq = 1e-2f; // experimentally determined approximate
-        const float thresh_low = params->scene_threshold_low * log10_pq;
-        const float thresh_high = params->scene_threshold_high * log10_pq;
-        const float bias = (float) frame_wg_active / frame_wg_count;
-        const float delta = bias * fabsf(avg_pq - obj->peak.avg_pq);
-        const float mix_coeff = pl_smoothstep(thresh_low, thresh_high, delta);
-        obj->peak.avg_pq = PL_MIX(obj->peak.avg_pq, avg_pq, mix_coeff);
-        obj->peak.max_pq = PL_MIX(obj->peak.max_pq, max_pq, mix_coeff);
-    }
+    // NEW: Completely different scene-change-detection algorithm, because the old one was not perfect and lead to screen flickering, as the black_detection feature is really sensitive.
+    const float smooth_coeff = iir_coeff(params->smoothing_period);
+    if (
+        (avg_pq > obj->peak.avg_pq + 0.01f*(float)params->scene_threshold_avg ||  // avg should be controlled relative, where [...]
+        avg_pq < obj->peak.avg_pq - 0.01f*(float)params->scene_threshold_avg)    // [...] threshold-setting in mpv.conf is absolute (in pq-%), where 7% pq-min equals to the display min.
+        &&
+        (min_pq > obj->peak.min_pq + 0.01f*(float)params->scene_threshold_low ||
+        min_pq < obj->peak.min_pq - 0.01f*(float)params->scene_threshold_low)
+    )
+        obj->peak.min_pq = min_pq;
+    else
+        obj->peak.min_pq += smooth_coeff * (min_pq - obj->peak.min_pq);
+
+    if (
+        (avg_pq >    obj->peak.avg_pq + 0.01f*(float)params->scene_threshold_avg ||
+        avg_pq <    obj->peak.avg_pq - 0.01f*(float)params->scene_threshold_avg)
+        &&
+        (max_pq >       obj->peak.max_pq    + 0.01f*(float)params->scene_threshold_high ||
+        max_pq <       obj->peak.max_pq    - 0.01f*(float)params->scene_threshold_high)
+    )
+        obj->peak.max_pq = max_pq;
+    else
+        obj->peak.max_pq += smooth_coeff * (max_pq - obj->peak.max_pq);
+
+    obj->peak.avg_pq = avg_pq;
 }
 
 bool pl_shader_detect_peak(pl_shader sh, struct pl_color_space csp,
@@ -1370,6 +1387,7 @@ bool pl_get_detected_hdr_metadata(const pl_shader_obj state,
 
     out->max_pq_y = obj->peak.max_pq;
     out->avg_pq_y = obj->peak.avg_pq;
+    out->min_pq_y = obj->peak.min_pq;
     return true;
 }
 

--- a/src/tests/options.c
+++ b/src/tests/options.c
@@ -53,9 +53,9 @@ int main()
     REQUIRE_CMP(*(int *) data->value, =, pl_render_default_params.tile_size, "d");
     REQUIRE_STREQ(data->text, "32");
 
-    const char *hq_opts = "upscaler=ewa_lanczossharp,downscaler=hermite,frame_mixer=oversample,deband=yes,sigmoid=yes,peak_detect=yes,peak_percentile=99.99500274658203,contrast_recovery=0.30000001192092896,dither=yes";
+    const char *hq_opts = "upscaler=ewa_lanczossharp,downscaler=hermite,frame_mixer=oversample,deband=yes,sigmoid=yes,peak_detect=yes,peak_percentile=99.99500274658203,black_percentile=0.5,black_maxadvance=4.900000095367432,contrast_recovery=0.30000001192092896,dither=yes";
     // fallback can produce different precision
-    const char *hq_opts2 = "upscaler=ewa_lanczossharp,downscaler=hermite,frame_mixer=oversample,deband=yes,sigmoid=yes,peak_detect=yes,peak_percentile=99.99500274658203125,contrast_recovery=0.30000001192092896,dither=yes";
+    const char *hq_opts2 = "upscaler=ewa_lanczossharp,downscaler=hermite,frame_mixer=oversample,deband=yes,sigmoid=yes,peak_detect=yes,peak_percentile=99.99500274658203125,black_percentile=0.4999,black_maxadvance=4.89999,contrast_recovery=0.30000001192092896,dither=yes";
 
     pl_options_reset(test, &pl_render_high_quality_params);
     const char *opts = pl_options_save(test);


### PR DESCRIPTION
Basically, all of the things that are done here, are discussed in https://github.com/haasn/libplacebo/discussions/303:

A Black Level feature is applied that works similar as the hdr-peak-detection.
It turned out that most movies do not have perfect black levels. They suffer from greyish looks in dark scenes.
This feature implements a black level detection that uses the screen-histogram used by the peak-detection.

As a side-gig it also uses a new algorithm for detecting scene-changes.
That means the way how it is decided if the min, avg and max PLL values are smoothed (during a scene), or applied directly from scene (when the scene changes).
It prevents from visible fading during scene-changes or flickering during ongoing scenes.