### PR TITLE
shaders/colorspace: fix shader compile error on Android and iOS

### DIFF
--- a/src/shaders/colorspace.c
+++ b/src/shaders/colorspace.c
@@ -53,9 +53,9 @@ static inline void reshape_mmr(pl_shader sh, ident_t mmr, bool single,
                                int min_order, int max_order)
 {
     if (single) {
-        GLSL("const uint mmr_idx = 0u; \n");
+        GLSL("const int mmr_idx = 0; \n");
     } else {
-        GLSL("uint mmr_idx = uint(coeffs.y); \n");
+        GLSL("int mmr_idx = int(coeffs.y); \n");
     }
 
     assert(min_order <= max_order);


### PR DESCRIPTION
uint and int addition on Android and iOS fails with following error: wrong operand types no operation '+' exists that takes a left-hand operand of type 'const uint' and a right operand of type 'const int' (or there is no acceptable conversion)